### PR TITLE
Add increment-version command to ci_tools CLI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "function-paren-newline": "off",
     "no-console": "off",
     "no-null/no-null": "off",
+    "object-curly-newline": "off",
     "object-curly-spacing": "off"
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,16 @@ steps:
   displayName: 'Install Node.js'
 
 - script: npm ci
-  displayName: 'Install Dependencies'
+  displayName: 'Install dependencies'
 
 - script: npm run build
-  displayName: 'Build Sources'
+  displayName: 'Build sources'
 
 - script: npm test
-  displayName: 'Run Tests'
+  displayName: 'Run tests'
 
 - script: npm run lint
-  displayName: 'Lint Sources'
+  displayName: 'Lint sources'
+
+- script: npm run ci-publish-if-applicable
+  displayName: 'Increment version & publish (if applicable)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,5 +34,10 @@ steps:
 - script: npm run lint
   displayName: 'Lint sources'
 
-- script: npm run ci-publish-if-applicable
+- script: |
+    # git remote set-url origin https://${GH_USER}:${GH_TOKEN}@github.com/process-engine/ci_tools.git
+    npm run ci-publish-if-applicable
   displayName: 'Increment version & publish (if applicable)'
+  # env:
+  #   GH_USER: $(GH_USER)
+  #   GH_TOKEN: $(GH_TOKEN)

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,12 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
@@ -180,6 +186,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -200,6 +212,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -229,8 +247,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "before-after-hook": {
       "version": "1.4.0",
@@ -241,21 +258,38 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "chalk": {
@@ -290,6 +324,23 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -308,8 +359,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "confusing-browser-globals": {
       "version": "1.0.7",
@@ -343,6 +393,12 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -357,6 +413,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -792,6 +854,15 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -812,8 +883,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -825,6 +895,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-stream": {
@@ -839,7 +915,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -861,6 +936,12 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -880,6 +961,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -956,7 +1043,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -965,8 +1051,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.3.1",
@@ -1006,10 +1091,27 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
       "dev": true
     },
     "is-callable": {
@@ -1098,6 +1200,15 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1141,10 +1252,53 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
       "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
+      }
     },
     "mime-db": {
       "version": "1.40.0",
@@ -1169,7 +1323,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1187,6 +1340,111 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -1210,6 +1468,16 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -1235,6 +1503,12 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -1264,6 +1538,16 @@
         "es-abstract": "^1.12.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "once": {
@@ -1297,6 +1581,17 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -1312,10 +1607,22 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -1368,8 +1675,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1385,8 +1691,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "2.0.0",
@@ -1466,10 +1771,30 @@
         "read-pkg": "^2.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requireindex": {
@@ -1482,7 +1807,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
       "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -1541,6 +1865,12 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1553,6 +1883,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1568,6 +1908,22 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
@@ -1714,6 +2070,27 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "ts-node": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -1796,6 +2173,21 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
     "windows-release": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
@@ -1810,6 +2202,53 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1823,6 +2262,216 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "yn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CI tools for process-engine.io",
   "main": "dist/index.js",
   "scripts": {
-    "ci-publish-if-applicable": "node dist/ci_tools.js increment-version --dry",
+    "ci-publish-if-applicable": "node dist/ci_tools.js increment-version --dry || true",
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
   "name": "@process-engine/ci_tools",
   "version": "1.1.0",
-  "description": "This Repository Holds Scripts That Are Used by Our CI",
+  "description": "CI tools for process-engine.io",
   "main": "dist/index.js",
   "scripts": {
+    "ci-publish-if-applicable": "node dist/ci_tools.js increment-version --dry",
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",
     "lint": "eslint src/**/*.ts src/*.ts",
-    "test": ":"
+    "test": "mocha -r ts-node/register src/**/*.test.ts"
   },
   "bin": {
-    "create-github-release": "./dist/commonjs/create-github-release.js",
-    "is-nuget-package-published:": "./dist/commonjs/is-nuget-package-published.js"
+    "ci_tools": "./dist/ci_tools.js",
+    "create-github-release": "./dist/legacy/create-github-release.js",
+    "is-nuget-package-published:": "./dist/legacy/is-nuget-package-published.js"
   },
   "repository": {
     "type": "git",
@@ -23,13 +25,17 @@
   "dependencies": {
     "@octokit/rest": "15.15.1",
     "mime-types": "^2.1.18",
-    "node-fetch": "^2.2.0"
+    "node-fetch": "^2.2.0",
+    "shelljs": "^0.8.3"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
+    "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.8",
     "eslint": "^5.16.0",
+    "mocha": "^6.1.4",
     "prettier": "^1.18.2",
+    "ts-node": "^8.1.0",
     "tsconfig": "^7.0.0",
     "typescript": "^3.5.2"
   }

--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -1,0 +1,18 @@
+import { run as incrementVersionRun } from './increment-version/index';
+
+const HANDLERS = { 'increment-version': incrementVersionRun };
+
+const [, , ...args] = process.argv;
+
+if (args.length === 0) {
+  console.log('Usage: TODO');
+  process.exit(1);
+}
+const [commandName, ...restArgs] = args;
+
+if (!HANDLERS[commandName]) {
+  console.log(`No handler found for command: ${commandName}`);
+  process.exit(1);
+}
+
+HANDLERS[commandName](...restArgs);

--- a/src/increment-version/git.ts
+++ b/src/increment-version/git.ts
@@ -1,0 +1,33 @@
+import { sh } from './shell';
+
+export function getGitTagList(): string {
+  return sh('git tag --list').trim();
+}
+
+export function getGitBranch(): string {
+  return process.env.GIT_BRANCH || sh('git rev-parse --abbrev-ref HEAD').trim();
+}
+
+export function isDirty(): boolean {
+  return sh('git status --porcelain --untracked-files=no').trim() !== '';
+}
+
+export function gitAdd(...files): string {
+  return sh(`git add ${files.join(' ')}`);
+}
+
+export function gitCommit(commitMessage): string {
+  return sh(`git commit -m "${commitMessage}"`);
+}
+
+export function gitTag(newTag): string {
+  return sh(`git tag ${newTag}`);
+}
+
+export function gitPush(): string {
+  return sh('git push');
+}
+
+export function gitPushTags(): string {
+  return sh('git push --tags');
+}

--- a/src/increment-version/increment_version.test.ts
+++ b/src/increment-version/increment_version.test.ts
@@ -14,34 +14,34 @@ v2.0.0-alpha2
 v2.0.0-alpha3
 v2.1.0-beta1`;
 
-describe('incrementVersion()', () => {
-  it('should return the incremented version for the first alpha build of a new version', () => {
+describe('incrementVersion()', (): void => {
+  it('should return the incremented version for the first alpha build of a new version', (): void => {
     assert.equal(incrementVersion('3.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha1');
   });
-  it('should return the incremented version for unknown pre-version suffixes', () => {
+  it('should return the incremented version for unknown pre-version suffixes', (): void => {
     assert.equal(incrementVersion('3.2.1-asdf5', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha1');
   });
-  it('should return the incremented version for subsequent alpha versions', () => {
+  it('should return the incremented version for subsequent alpha versions', (): void => {
     assert.equal(incrementVersion('1.2.1-alpha7', BRANCH_DEVELOP, GIT_TAG_LIST), '1.2.1-alpha11');
   });
 
-  it('should return the incremented version for the first beta build of a alpha version', () => {
+  it('should return the incremented version for the first beta build of a alpha version', (): void => {
     assert.equal(incrementVersion('3.2.1-alpha3', BRANCH_BETA, GIT_TAG_LIST), '3.2.1-beta1');
   });
-  it('should return the incremented version for subsequent beta versions', () => {
+  it('should return the incremented version for subsequent beta versions', (): void => {
     // v3.2.1-beta3 not in tag list, falling back to numbering found there
     assert.equal(incrementVersion('2.1.0-beta3', BRANCH_BETA, GIT_TAG_LIST), '2.1.0-beta2');
   });
-  it('should return the incremented version for the stable build of a alpha version', () => {
+  it('should return the incremented version for the stable build of a alpha version', (): void => {
     assert.equal(incrementVersion('3.2.1-alpha42', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
   });
-  it('should return the incremented version for the stable build of a beta version', () => {
+  it('should return the incremented version for the stable build of a beta version', (): void => {
     assert.equal(incrementVersion('3.2.1-beta4', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
   });
 });
 
-describe('findNextSuffixNumber()', () => {
-  it('should work', () => {
+describe('findNextSuffixNumber()', (): void => {
+  it('should work', (): void => {
     assert.equal(findNextSuffixNumber('1.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), 11);
     assert.equal(findNextSuffixNumber('1.3.0', BRANCH_DEVELOP, GIT_TAG_LIST), 1);
     assert.equal(findNextSuffixNumber('2.0.0', BRANCH_DEVELOP, GIT_TAG_LIST), 4);

--- a/src/increment-version/increment_version.test.ts
+++ b/src/increment-version/increment_version.test.ts
@@ -29,7 +29,7 @@ describe('incrementVersion()', (): void => {
     assert.equal(incrementVersion('3.2.1-alpha3', BRANCH_BETA, GIT_TAG_LIST), '3.2.1-beta1');
   });
   it('should return the incremented version for subsequent beta versions', (): void => {
-    // v3.2.1-beta3 not in tag list, falling back to numbering found there
+    // v2.1.0-beta3 not in tag list, falling back to numbering found there
     assert.equal(incrementVersion('2.1.0-beta3', BRANCH_BETA, GIT_TAG_LIST), '2.1.0-beta2');
   });
   it('should return the incremented version for the stable build of a alpha version', (): void => {

--- a/src/increment-version/increment_version.test.ts
+++ b/src/increment-version/increment_version.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import { findNextSuffixNumber, incrementVersion } from './increment_version';
+
+const BRANCH_DEVELOP = 'develop';
+const BRANCH_BETA = 'beta';
+const BRANCH_MASTER = 'master';
+
+const GIT_TAG_LIST = `v1.2.1-alpha10
+v1.2.1-alpha7
+v1.2.1-alpha8
+v1.2.1-alpha9
+v2.0.0-alpha1
+v2.0.0-alpha2
+v2.0.0-alpha3
+v2.1.0-beta1`;
+
+describe('incrementVersion()', () => {
+  it('should return the incremented version for the first alpha build of a new version', () => {
+    assert.equal(incrementVersion('3.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha1');
+  });
+  it('should return the incremented version for unknown pre-version suffixes', () => {
+    assert.equal(incrementVersion('3.2.1-asdf5', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha1');
+  });
+  it('should return the incremented version for subsequent alpha versions', () => {
+    assert.equal(incrementVersion('1.2.1-alpha7', BRANCH_DEVELOP, GIT_TAG_LIST), '1.2.1-alpha11');
+  });
+
+  it('should return the incremented version for the first beta build of a alpha version', () => {
+    assert.equal(incrementVersion('3.2.1-alpha3', BRANCH_BETA, GIT_TAG_LIST), '3.2.1-beta1');
+  });
+  it('should return the incremented version for subsequent beta versions', () => {
+    // v3.2.1-beta3 not in tag list, falling back to numbering found there
+    assert.equal(incrementVersion('2.1.0-beta3', BRANCH_BETA, GIT_TAG_LIST), '2.1.0-beta2');
+  });
+  it('should return the incremented version for the stable build of a alpha version', () => {
+    assert.equal(incrementVersion('3.2.1-alpha42', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
+  });
+  it('should return the incremented version for the stable build of a beta version', () => {
+    assert.equal(incrementVersion('3.2.1-beta4', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
+  });
+});
+
+describe('findNextSuffixNumber()', () => {
+  it('should work', () => {
+    assert.equal(findNextSuffixNumber('1.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), 11);
+    assert.equal(findNextSuffixNumber('1.3.0', BRANCH_DEVELOP, GIT_TAG_LIST), 1);
+    assert.equal(findNextSuffixNumber('2.0.0', BRANCH_DEVELOP, GIT_TAG_LIST), 4);
+    assert.equal(findNextSuffixNumber('2.1.0', BRANCH_DEVELOP, GIT_TAG_LIST), 1);
+
+    assert.equal(findNextSuffixNumber('1.2.1', BRANCH_BETA, GIT_TAG_LIST), 1);
+    assert.equal(findNextSuffixNumber('2.0.0', BRANCH_BETA, GIT_TAG_LIST), 1);
+    assert.equal(findNextSuffixNumber('2.1.0', BRANCH_BETA, GIT_TAG_LIST), 2);
+    assert.equal(findNextSuffixNumber('2.2.0', BRANCH_BETA, GIT_TAG_LIST), 1);
+  });
+});

--- a/src/increment-version/increment_version.ts
+++ b/src/increment-version/increment_version.ts
@@ -1,0 +1,59 @@
+const NO_PRE_VERSION = 'NO_PRE_VERSION';
+const PRE_VERSION_SUFFIX_MAP = {
+  develop: 'alpha',
+  beta: 'beta',
+  master: NO_PRE_VERSION
+};
+
+export const VERSION_INCREMENTER_BRANCHES = Object.keys(PRE_VERSION_SUFFIX_MAP);
+
+export function findNextSuffixNumber(baseVersion: string, branchName: string, tagList: string): number | null {
+  const targetVersion = getTargetVersion(baseVersion);
+  const preVersionSuffix = getPreVersionSuffix(branchName);
+
+  if (preVersionSuffix == null) {
+    return null;
+  }
+
+  const versionPrefix = `v${targetVersion}-${preVersionSuffix}`;
+  const existingTags = tagList.split('\n').filter((tag: string): boolean => tag.trim().indexOf(versionPrefix) === 0);
+
+  if (existingTags.length === 0) {
+    return 1;
+  }
+
+  const existingNumbers = existingTags.map((tag: string): number => {
+    const matchData = tag.match(/(\d+)$/);
+
+    return parseInt(matchData[0]);
+  });
+  const sortedNumbersDesc = existingNumbers.sort((a: number, b: number): number => b - a);
+
+  return sortedNumbersDesc[0] + 1; // TODO: implement me
+}
+
+export function incrementVersion(packageVersion: string, branchName: string, gitTagList: string): string | null {
+  const targetVersion = getTargetVersion(packageVersion);
+  const preVersionSuffix = getPreVersionSuffix(branchName);
+
+  if (preVersionSuffix === NO_PRE_VERSION) {
+    return targetVersion;
+  }
+  if (preVersionSuffix == null) {
+    return null;
+  }
+
+  const nextSuffixNumber = findNextSuffixNumber(packageVersion, branchName, gitTagList);
+
+  return `${targetVersion}-${preVersionSuffix}${nextSuffixNumber}`;
+}
+
+function getTargetVersion(baseVersion: string): string {
+  const targetBase = baseVersion.split('-')[0];
+
+  return targetBase.trim().replace(/^v/, '');
+}
+
+function getPreVersionSuffix(branchName: string): string {
+  return PRE_VERSION_SUFFIX_MAP[branchName];
+}

--- a/src/increment-version/increment_version.ts
+++ b/src/increment-version/increment_version.ts
@@ -5,7 +5,7 @@ const PRE_VERSION_SUFFIX_MAP = {
   master: NO_PRE_VERSION
 };
 
-export const VERSION_INCREMENTER_BRANCHES = Object.keys(PRE_VERSION_SUFFIX_MAP);
+export const APPLICABLE_BRANCHES = Object.keys(PRE_VERSION_SUFFIX_MAP);
 
 export function findNextSuffixNumber(baseVersion: string, branchName: string, tagList: string): number | null {
   const targetVersion = getTargetVersion(baseVersion);

--- a/src/increment-version/index.ts
+++ b/src/increment-version/index.ts
@@ -1,0 +1,61 @@
+import { getPackageVersion } from './package_version';
+import { getGitBranch, getGitTagList, gitAdd, gitCommit, gitPush, gitPushTags, gitTag, isDirty } from './git';
+import { VERSION_INCREMENTER_BRANCHES, incrementVersion } from './increment_version';
+import { sh } from './shell';
+
+const BADGE = '[increment-version]\t';
+
+export async function run(...args): Promise<void> {
+  const isDryRun = args.indexOf('--dry') !== -1;
+  const isForced = args.indexOf('--force') !== -1;
+
+  const packageVersion = getPackageVersion();
+  const branchName = getGitBranch();
+  const gitTagList = getGitTagList();
+
+  const nextVersion = incrementVersion(packageVersion, branchName, gitTagList);
+
+  console.log(`${BADGE}isDryRun:`, isDryRun);
+  console.log(`${BADGE}isForced:`, isForced);
+  console.log('');
+  console.log(`${BADGE}packageVersion:`, packageVersion);
+  console.log(`${BADGE}branchName:`, branchName);
+  console.log(`${BADGE}gitTagList:`);
+  gitTagList.split('\n').forEach((line: string): void => console.log(`${BADGE}  ${line}`));
+  console.log('');
+
+  if (nextVersion == null) {
+    console.error(`${BADGE}Aborting since we are not on one of these branches:`);
+    console.error(`${BADGE}  ${VERSION_INCREMENTER_BRANCHES.join(', ')}`);
+    process.exit(1);
+  }
+
+  commitPushAndTagNextVersion(nextVersion, isForced, isDryRun);
+}
+
+function commitPushAndTagNextVersion(nextVersion: string, isForced: boolean, isDryRun: boolean): void {
+  const nextTag = `v${nextVersion}`;
+  const nextCommitMessage = `Bump version to ${nextVersion}`;
+
+  if (isDirty() && !isForced) {
+    const workdirState = sh('git status --porcelain --untracked-files=no').trim();
+
+    console.error(`${BADGE}Can not proceed due to dirty git workdir:\n\n${workdirState}`);
+
+    process.exit(1);
+  }
+
+  if (isDryRun) {
+    console.log(`${BADGE}I would commit version ${nextVersion} in package.json with message "${nextCommitMessage}"`);
+    console.log(`${BADGE}I would tag the last commit as "${nextTag}"`);
+
+    return;
+  }
+
+  sh(`npm version ${nextVersion}`);
+  gitAdd('package.json');
+  gitCommit(nextCommitMessage);
+  gitTag(nextTag);
+  gitPush();
+  gitPushTags();
+}

--- a/src/increment-version/index.ts
+++ b/src/increment-version/index.ts
@@ -5,6 +5,16 @@ import { sh } from './shell';
 
 const BADGE = '[increment-version]\t';
 
+/**
+ * Increments the version in `package.json` automatically, adds a suffix to the version, tags and publishes it
+ * (when on one of the applicable branches).
+ *
+ * Example:
+ *
+ *    current version:  1.2.0-beta2
+ *    new version:      1.2.0-beta3
+ *    new tag:         v1.2.0-beta3
+ */
 export async function run(...args): Promise<void> {
   const isDryRun = args.indexOf('--dry') !== -1;
   const isForced = args.indexOf('--force') !== -1;

--- a/src/increment-version/index.ts
+++ b/src/increment-version/index.ts
@@ -1,6 +1,6 @@
 import { getPackageVersion } from './package_version';
 import { getGitBranch, getGitTagList, gitAdd, gitCommit, gitPush, gitPushTags, gitTag, isDirty } from './git';
-import { VERSION_INCREMENTER_BRANCHES, incrementVersion } from './increment_version';
+import { APPLICABLE_BRANCHES, incrementVersion } from './increment_version';
 import { sh } from './shell';
 
 const BADGE = '[increment-version]\t';
@@ -8,40 +8,31 @@ const BADGE = '[increment-version]\t';
 export async function run(...args): Promise<void> {
   const isDryRun = args.indexOf('--dry') !== -1;
   const isForced = args.indexOf('--force') !== -1;
+  const isDirtyAndNotForced = isDirty() && !isForced;
 
   const packageVersion = getPackageVersion();
   const branchName = getGitBranch();
   const gitTagList = getGitTagList();
 
   const nextVersion = incrementVersion(packageVersion, branchName, gitTagList);
+  const notOnApplicableBranch = nextVersion == null;
+  const nextCommitMessage = `Bump version to ${nextVersion}`;
+  const nextTag = `v${nextVersion}`;
 
-  console.log(`${BADGE}isDryRun:`, isDryRun);
-  console.log(`${BADGE}isForced:`, isForced);
-  console.log('');
-  console.log(`${BADGE}packageVersion:`, packageVersion);
-  console.log(`${BADGE}branchName:`, branchName);
-  console.log(`${BADGE}gitTagList:`);
-  gitTagList.split('\n').forEach((line: string): void => console.log(`${BADGE}  ${line}`));
-  console.log('');
+  printInfo(packageVersion, branchName, gitTagList, isDryRun, isForced);
 
-  if (nextVersion == null) {
-    console.error(`${BADGE}Aborting since we are not on one of these branches:`);
-    console.error(`${BADGE}  ${VERSION_INCREMENTER_BRANCHES.join(', ')}`);
+  if (isDirtyAndNotForced) {
+    const workdirState = sh('git status --porcelain --untracked-files=no').trim();
+
+    console.error(`${BADGE}Can not proceed due to dirty git workdir:`);
+    printMultiLineString(workdirState);
+
     process.exit(1);
   }
 
-  commitPushAndTagNextVersion(nextVersion, isForced, isDryRun);
-}
-
-function commitPushAndTagNextVersion(nextVersion: string, isForced: boolean, isDryRun: boolean): void {
-  const nextTag = `v${nextVersion}`;
-  const nextCommitMessage = `Bump version to ${nextVersion}`;
-
-  if (isDirty() && !isForced) {
-    const workdirState = sh('git status --porcelain --untracked-files=no').trim();
-
-    console.error(`${BADGE}Can not proceed due to dirty git workdir:\n\n${workdirState}`);
-
+  if (notOnApplicableBranch) {
+    console.error(`${BADGE}Aborting since we are not on one of these branches:`);
+    console.error(`${BADGE}  ${APPLICABLE_BRANCHES.join(', ')}`);
     process.exit(1);
   }
 
@@ -52,6 +43,31 @@ function commitPushAndTagNextVersion(nextVersion: string, isForced: boolean, isD
     return;
   }
 
+  commitPushAndTagNextVersion(nextVersion, nextTag, nextCommitMessage);
+}
+
+function printInfo(
+  packageVersion: string,
+  branchName: string,
+  gitTagList: string,
+  isDryRun: boolean,
+  isForced: boolean
+): void {
+  console.log(`${BADGE}isDryRun:`, isDryRun);
+  console.log(`${BADGE}isForced:`, isForced);
+  console.log('');
+  console.log(`${BADGE}packageVersion:`, packageVersion);
+  console.log(`${BADGE}branchName:`, branchName);
+  console.log(`${BADGE}gitTagList:`);
+  printMultiLineString(gitTagList);
+  console.log('');
+}
+
+function printMultiLineString(text: string): void {
+  text.split('\n').forEach((line: string): void => console.log(`${BADGE}  ${line}`));
+}
+
+function commitPushAndTagNextVersion(nextVersion: string, nextTag: string, nextCommitMessage: string): void {
   sh(`npm version ${nextVersion}`);
   gitAdd('package.json');
   gitCommit(nextCommitMessage);

--- a/src/increment-version/package_version.ts
+++ b/src/increment-version/package_version.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+
+export function getPackageVersion(): string {
+  const rawdata = fs.readFileSync('package.json').toString();
+  const packageJson = JSON.parse(rawdata);
+
+  return packageJson.version;
+}

--- a/src/increment-version/shell.ts
+++ b/src/increment-version/shell.ts
@@ -1,0 +1,5 @@
+import * as shell from 'shelljs';
+
+export function sh(command: string): string {
+  return shell.exec(command, { silent: true }).toString();
+}

--- a/src/legacy/create-github-release.ts
+++ b/src/legacy/create-github-release.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as Octokit from '@octokit/rest';
 import { readFileSync, statSync } from 'fs';
 import * as mime from 'mime-types';

--- a/src/legacy/is-nuget-package-published.ts
+++ b/src/legacy/is-nuget-package-published.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as fetch from 'node-fetch';
 
 interface IApiIndex {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,13 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2018",
-    "lib": [
-      "es2018"
-    ],
+    "lib": ["es2018"],
     "declaration": true,
     "skipLibCheck": true,
     "declarationDir": "./dist",
     "sourceMap": true,
     "experimentalDecorators": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Fügt eine `bin` namens `ci_tools` hinzu, welche als erstes Subcommand `increment-version` kennt.

Die Binaries `create-github-release` und `is-nuget-package-published` werden natürlich weiterhin geführt.
