### PR TITLE
Add command npm-ci-except

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,15 +42,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
-          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-          "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+          "version": "10.14.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
+          "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==",
           "dev": true
         }
       }
@@ -84,9 +78,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
-      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
+      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==",
       "dev": true
     },
     "@types/strip-bom": {
@@ -102,12 +96,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.10.2.tgz",
-      "integrity": "sha512-7449RhjE1oLFIy5E/5rT4wG5+KsfPzakJuhvpzXJ3C46lq7xywY0/Rjo9ZBcwrfbk0nRZ5xmUHkk7DZ67tSBKw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.11.0.tgz",
+      "integrity": "sha512-mXv9ccCou89C8/4avKHuPB2WkSZyY/XcTQUXd5LFZAcLw1I3mWYVjUu6eS9Ja0QkP/ClolbcW9tb3Ov/pMdcqw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "1.10.2",
+        "@typescript-eslint/experimental-utils": "1.11.0",
         "eslint-utils": "^1.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
@@ -115,31 +109,31 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.10.2.tgz",
-      "integrity": "sha512-Hf5lYcrnTH5Oc67SRrQUA7KuHErMvCf5RlZsyxXPIT6AXa8fKTyfFO6vaEnUmlz48RpbxO4f0fY3QtWkuHZNjg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.11.0.tgz",
+      "integrity": "sha512-7LbfaqF6B8oa8cp/315zxKk8FFzosRzzhF8Kn/ZRsRsnpm7Qcu25cR/9RnAQo5utZ2KIWVgaALr+ZmcbG47ruw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.10.2",
+        "@typescript-eslint/typescript-estree": "1.11.0",
         "eslint-scope": "^4.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.10.2.tgz",
-      "integrity": "sha512-xWDWPfZfV0ENU17ermIUVEVSseBBJxKfqBcRCMZ8nAjJbfA5R7NWMZmFFHYnars5MjK4fPjhu4gwQv526oZIPQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.11.0.tgz",
+      "integrity": "sha512-5xBExyXaxVyczrZvbRKEXvaTUFFq7gIM9BynXukXZE0zF3IQP/FxF4mPmmh3gJ9egafZFqByCpPTFm3dk4SY7Q==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.10.2",
-        "@typescript-eslint/typescript-estree": "1.10.2",
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "@typescript-eslint/typescript-estree": "1.11.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.10.2.tgz",
-      "integrity": "sha512-Kutjz0i69qraOsWeI8ETqYJ07tRLvD9URmdrMoF10bG8y8ucLmPtSxROvVejWvlJUGl2et/plnMiKRDW+rhEhw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.11.0.tgz",
+      "integrity": "sha512-fquUHF5tAx1sM2OeRCC7wVxFd1iMELWMGCzOSmJ3pLzArj9+kRixdlC4d5MncuzXpjEqc6045p3KwM0o/3FuUA==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -658,9 +652,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
-      "integrity": "sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
+      "integrity": "sha512-PZpAEC4gj/6DEMMoU2Df01C5c50r7zdGIN52Yfi7CvvWaYssG7Jt5R9nFG5gmqodxNOz9vQS87xk6Izdtpdrig==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -931,9 +925,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
     "growl": {
@@ -1957,9 +1951,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
-    "@essential-projects/eslint-config": "^1.0.0",
+    "@essential-projects/eslint-config": "^1.0.4",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.0.8",
+    "@types/node": "^12.6.2",
     "eslint": "^5.16.0",
     "mocha": "^6.1.4",
     "prettier": "^1.18.2",

--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -1,10 +1,12 @@
 import { run as autoPublishIfApplicableRun } from './commands/auto-publish-if-applicable';
+import { run as npmCiExcept } from './commands/npm-ci-except';
 import { run as createChangelogRun } from './commands/create-changelog';
 import { run as incrementVersionRun } from './commands/increment-version';
 import { run as setupGitAndNpmRun } from './commands/setup-git-and-npm';
 
 const COMMAND_HANDLERS = {
   'auto-publish-if-applicable': autoPublishIfApplicableRun,
+  'npm-ci-except': npmCiExcept,
   'create-changelog': createChangelogRun,
   'increment-version': incrementVersionRun,
   'setup-git-and-npm': setupGitAndNpmRun
@@ -13,7 +15,10 @@ const COMMAND_HANDLERS = {
 const [, , ...args] = process.argv;
 
 if (args.length === 0) {
-  console.log('Usage: TODO');
+  console.log('Usage: ci_tools <COMMAND>');
+  console.log('');
+  console.log('COMMAND can be any of:');
+  Object.keys(COMMAND_HANDLERS).forEach((commandName: string): void => console.log(`  ${commandName}`));
   process.exit(1);
 }
 const [commandName, ...restArgs] = args;

--- a/src/commands/npm-ci-except.ts
+++ b/src/commands/npm-ci-except.ts
@@ -1,0 +1,67 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+
+import { sh } from '../git/shell';
+
+const BADGE = '[npm-ci-except]\t';
+
+export async function run(...args): Promise<boolean> {
+  const isDryRun = args.indexOf('--dry') !== -1;
+
+  const allPackageNames = getAllPackageNames();
+  const patternList = args.filter((arg: string): boolean => !arg.startsWith('-'));
+  const foundPatternMatchingPackages = getPackageNamesMatchingPattern(allPackageNames, patternList);
+
+  console.log(`${BADGE}`);
+  console.log(`${BADGE}allPackageNames:`, allPackageNames);
+  console.log(`${BADGE}patternList:`, patternList);
+  console.log(`${BADGE}foundPatternMatchingPackages:`, foundPatternMatchingPackages);
+
+  console.log(`${BADGE}`);
+
+  annotatedSh('npm ci', isDryRun);
+
+  foundPatternMatchingPackages.forEach((packageName: string): void => {
+    annotatedSh(`npm install ${packageName}`, isDryRun);
+  });
+
+  return true;
+}
+
+function annotatedSh(command: string, isDryRun: boolean): void {
+  console.log(`${BADGE}`);
+  console.log(`${BADGE}Running: ${chalk.cyan(command)}`);
+
+  if (isDryRun) {
+    console.log(chalk.yellow('\n  [skipping execution due to --dry]\n'));
+    return;
+  }
+
+  const output = sh(command);
+  console.log(output);
+}
+
+function getPackageNamesMatchingPattern(allPackageNames: string[], patternList: string[]): string[] {
+  let foundPatternMatchingPackages = [];
+
+  patternList.forEach((nameStart: string): void => {
+    const packages = allPackageNames.filter((packageName: string): boolean => {
+      return packageName.startsWith(nameStart);
+    });
+
+    foundPatternMatchingPackages = foundPatternMatchingPackages.concat(packages);
+  });
+
+  return foundPatternMatchingPackages;
+}
+
+function getAllPackageNames(): string[] {
+  const content = readFileSync('package.json').toString();
+  const json = JSON.parse(content);
+
+  const dependencies: string[] = Object.keys(json.dependencies);
+  const devDependencies: string[] = Object.keys(json.devDependencies);
+  const allPackageNames: string[] = [...dependencies].concat(devDependencies).sort();
+
+  return allPackageNames;
+}


### PR DESCRIPTION
Fügt ein Kommando hinzu, dass alle Deps per `npm ci`, aber zusätzlich die Deps, die mit den angegebenen Namen anfangen, per `npm install` aktualisiert (das ist wünschenswert, wenn wir bspw. Pakete per Tag referenziert haben).

Dieser Schritt soll perspektivisch den `npm ci`-Step in unserer CI ersetzen.

```
ci_tools npm-ci-except @process-engine/ @essential-projects/
```

würde bspw. alle Pakete per `npm ci` installieren und anschließend einzeln alle Pakete, die entweder mit `@process-engine/` oder `@essential-projects/` anfangen, per `npm install` hochziehen.