### PR TITLE
Rename npm-ci-except -> npm-install-only

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -1,15 +1,15 @@
-import { run as autoPublishIfApplicableRun } from './commands/auto-publish-if-applicable';
-import { run as npmCiExcept } from './commands/npm-ci-except';
-import { run as createChangelogRun } from './commands/create-changelog';
-import { run as incrementVersionRun } from './commands/increment-version';
-import { run as setupGitAndNpmRun } from './commands/setup-git-and-npm';
+import { run as runAutoPublishIfApplicable } from './commands/auto-publish-if-applicable';
+import { run as runNpmInstallOnly } from './commands/npm-install-only';
+import { run as runCreateChangelog } from './commands/create-changelog';
+import { run as runIncrementVersion } from './commands/increment-version';
+import { run as runSetupGitAndNpm } from './commands/setup-git-and-npm';
 
 const COMMAND_HANDLERS = {
-  'auto-publish-if-applicable': autoPublishIfApplicableRun,
-  'npm-ci-except': npmCiExcept,
-  'create-changelog': createChangelogRun,
-  'increment-version': incrementVersionRun,
-  'setup-git-and-npm': setupGitAndNpmRun
+  'auto-publish-if-applicable': runAutoPublishIfApplicable,
+  'create-changelog': runCreateChangelog,
+  'increment-version': runIncrementVersion,
+  'npm-install-only': runNpmInstallOnly,
+  'setup-git-and-npm': runSetupGitAndNpm
 };
 
 const [, , ...args] = process.argv;

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+
+import { sh } from '../git/shell';
+
+const BADGE = '[npm-install-only]\t';
+
+export async function run(...args): Promise<boolean> {
+  const isDryRun = args.indexOf('--dry') !== -1;
+
+  const allPackageNames = getAllPackageNames();
+  const patternList = args.filter((arg: string): boolean => !arg.startsWith('-'));
+  const foundPatternMatchingPackages = getPackageNamesMatchingPattern(allPackageNames, patternList);
+
+  console.log(`${BADGE}`);
+  console.log(`${BADGE}allPackageNames:`, allPackageNames);
+  console.log(`${BADGE}patternList:`, patternList);
+  console.log(`${BADGE}foundPatternMatchingPackages:`, foundPatternMatchingPackages);
+
+  console.log(`${BADGE}`);
+
+  foundPatternMatchingPackages.forEach((packageName: string): void => {
+    annotatedSh(`npm install ${packageName}`, isDryRun);
+  });
+
+  return true;
+}
+
+function annotatedSh(command: string, isDryRun: boolean): void {
+  console.log(`${BADGE}`);
+  console.log(`${BADGE}Running: ${chalk.cyan(command)}`);
+
+  if (isDryRun) {
+    console.log(chalk.yellow('\n  [skipping execution due to --dry]\n'));
+    return;
+  }
+
+  const output = sh(command);
+  console.log(output);
+}
+
+function getPackageNamesMatchingPattern(allPackageNames: string[], patternList: string[]): string[] {
+  let foundPatternMatchingPackages = [];
+
+  patternList.forEach((nameStart: string): void => {
+    const packages = allPackageNames.filter((packageName: string): boolean => {
+      return packageName.startsWith(nameStart);
+    });
+
+    foundPatternMatchingPackages = foundPatternMatchingPackages.concat(packages);
+  });
+
+  return foundPatternMatchingPackages;
+}
+
+function getAllPackageNames(): string[] {
+  const content = readFileSync('package.json').toString();
+  const json = JSON.parse(content);
+
+  const dependencies: string[] = Object.keys(json.dependencies);
+  const devDependencies: string[] = Object.keys(json.devDependencies);
+  const allPackageNames: string[] = [...dependencies].concat(devDependencies).sort();
+
+  return allPackageNames;
+}


### PR DESCRIPTION
Renames the `npm-ci-except` command to `npm-install-only`. Does no longer run `npm ci` before
installing the pattern matches packages via `npm install` to provide more flexibility to the CI.

```
$ ci_tools npm-install-only @process-engine/
```

is also probably more "self explanatory".