### PR TITLE
Add "update-github-release" command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "no-null/no-null": "off",
     "object-curly-newline": "off",
     "object-shorthand": "off",
-    "object-curly-spacing": "off"
+    "object-curly-spacing": "off",
+    "no-lonely-if": "warn"
   }
 }

--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -1,15 +1,17 @@
-import { run as autoPublishIfApplicableRun } from './commands/auto-publish-if-applicable';
-import { run as npmCiExcept } from './commands/npm-ci-except';
-import { run as createChangelogRun } from './commands/create-changelog';
-import { run as incrementVersionRun } from './commands/increment-version';
-import { run as setupGitAndNpmRun } from './commands/setup-git-and-npm';
+import { run as runAutoPublishIfApplicable } from './commands/auto-publish-if-applicable';
+import { run as runNpmCiExcept } from './commands/npm-ci-except';
+import { run as runCreateChangelog } from './commands/create-changelog';
+import { run as runUpdateGithubRelease } from './commands/update-github-release';
+import { run as runIncrementVersion } from './commands/increment-version';
+import { run as runSetupGitAndNpm } from './commands/setup-git-and-npm';
 
 const COMMAND_HANDLERS = {
-  'auto-publish-if-applicable': autoPublishIfApplicableRun,
-  'npm-ci-except': npmCiExcept,
-  'create-changelog': createChangelogRun,
-  'increment-version': incrementVersionRun,
-  'setup-git-and-npm': setupGitAndNpmRun
+  'auto-publish-if-applicable': runAutoPublishIfApplicable,
+  'create-changelog': runCreateChangelog,
+  'increment-version': runIncrementVersion,
+  'update-github-release': runUpdateGithubRelease,
+  'npm-ci-except': runNpmCiExcept,
+  'setup-git-and-npm': runSetupGitAndNpm
 };
 
 const [, , ...args] = process.argv;

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -15,7 +15,7 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`, argv);
 
-  const success = await updateGitHubRelease(argv.versionTag, argv.title, argv.text, !!argv.dry);
+  const success = await updateGitHubRelease(argv.versionTag, argv.title, argv.text, argv.dry);
 
   if (success) {
     console.log(`${BADGE}Success.`);
@@ -86,7 +86,7 @@ async function createNewRelease(
   title: string,
   text: string
 ): Promise<boolean> {
-  const isPrerelease = !!versionTag.match(/-/);
+  const isPrerelease = versionTag.match(/-/) != null;
 
   const response = await octokit.repos.createRelease({
     owner: repo.owner,

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -1,0 +1,135 @@
+import * as Octokit from '@octokit/rest';
+import * as yargsParser from 'yargs-parser';
+import { getCurrentRepoNameWithOwner } from '../git/git';
+
+const BADGE = '[update-github-release]\t';
+
+type GitTag = string;
+type GitHubRepo = {
+  owner: string;
+  name: string;
+};
+
+export async function run(...args): Promise<boolean> {
+  const argv = yargsParser(args);
+
+  console.log(`${BADGE}`, argv);
+
+  const success = await updateGitHubRelease(argv.versionTag, argv.title, argv.text, !!argv.dry);
+
+  if (success) {
+    console.log(`${BADGE}Success.`);
+  }
+
+  return success;
+}
+
+/**
+ * Updates the corresponding GitHub release for `versionTag` using the given `title` and `text`.
+ */
+export async function updateGitHubRelease(
+  versionTag: GitTag,
+  title: string,
+  text: string,
+  dryRun: boolean = false
+): Promise<boolean> {
+  const repo = getCurrentRepoNameWithOwnerAsObject(getCurrentRepoNameWithOwner());
+  const octokit = await createOctokit(process.env.GH_TOKEN);
+  const releaseId = await getExistingReleaseId(octokit, repo, versionTag);
+  const releaseExists = releaseId != null;
+
+  if (releaseExists) {
+    if (dryRun) {
+      console.log(`${BADGE}Would now update existing release. Skipping since this is a dry run!`);
+
+      return true;
+    }
+
+    console.log(`${BADGE}Updating existing release for ${versionTag} ...`);
+
+    return updateExistingRelease(octokit, repo, releaseId, title, text);
+  }
+
+  if (dryRun) {
+    console.log(`${BADGE}Would now create a new release. Skipping since this is a dry run!`);
+
+    return true;
+  }
+
+  console.log(`${BADGE}Creating new release for ${versionTag} ...`);
+
+  return createNewRelease(octokit, repo, versionTag, title, text);
+}
+
+async function updateExistingRelease(
+  octokit: Octokit,
+  repo: GitHubRepo,
+  releaseId: number,
+  title: string,
+  text: string
+): Promise<boolean> {
+  const response = await octokit.repos.editRelease({
+    owner: repo.owner,
+    repo: repo.name,
+    release_id: releaseId,
+    name: title,
+    body: text
+  });
+
+  return response.status === 200;
+}
+
+async function createNewRelease(
+  octokit: Octokit,
+  repo: GitHubRepo,
+  versionTag: GitTag,
+  title: string,
+  text: string
+): Promise<boolean> {
+  const isPrerelease = !!versionTag.match(/-/);
+
+  const response = await octokit.repos.createRelease({
+    owner: repo.owner,
+    repo: repo.name,
+    tag_name: versionTag,
+    name: title,
+    body: text,
+    prerelease: isPrerelease
+  });
+
+  return response.status === 200;
+}
+
+async function createOctokit(githubAuthToken: string): Promise<Octokit> {
+  const octokit = new Octokit();
+
+  await octokit.authenticate({
+    type: 'token',
+    token: githubAuthToken
+  });
+
+  return octokit;
+}
+
+function getCurrentRepoNameWithOwnerAsObject(nameWithOwner: string): GitHubRepo {
+  const parts = nameWithOwner.split('/');
+
+  return {
+    name: parts[1],
+    owner: parts[0]
+  };
+}
+
+async function getExistingReleaseId(octokit: Octokit, repo: GitHubRepo, versionTag: GitTag): Promise<number | null> {
+  try {
+    const response = await octokit.repos.getReleaseByTag({
+      owner: repo.owner,
+      repo: repo.name,
+      tag: versionTag
+    });
+
+    return response.data.id;
+  } catch (error) {
+    return null;
+  }
+}

--- a/src/versions/increment_version.ts
+++ b/src/versions/increment_version.ts
@@ -29,7 +29,7 @@ export function findNextSuffixNumber(baseVersion: string, branchName: string, ta
   });
   const sortedNumbersDesc = existingNumbers.sort((a: number, b: number): number => b - a);
 
-  return sortedNumbersDesc[0] + 1; // TODO: implement me
+  return sortedNumbersDesc[0] + 1;
 }
 
 export function incrementVersion(packageVersion: string, branchName: string, gitTagList: string): string | null {


### PR DESCRIPTION
Fügt ein Kommando `update-github-release` hinzu, dass Titel und Text eines GitHub-Releases setzt.

```
ci_tools update-github-release --version-tag "v1.2.0" --title "RELEASE! v1.2.0 😎" --text "Dies ist ein Test!!!"
```

Das Kommando funktioniert deklarativ, soll heißen, es ist unerheblich, ob zu dem gegebenen Tag schon ein Release auf GitHub existiert (in diesem Fall wird das bestehende so geupdatet, dass der angegebene Zustand nach Ausführung des Kommandos erreicht ist).