### PR TITLE
Add assets option update GitHub release command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1233,9 +1233,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.unescape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@octokit/rest": "15.15.1",
     "chalk": "^2.4.2",
     "compare-versions": "^3.4.0",
+    "glob": "^7.1.4",
     "mime-types": "^2.1.18",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
Fügt einen Switch `--assets` hinzu, um Assets an ein GitHub-Release anzufügen.

Das Kommando ist deklarativ, idempotent und unterstützt "glob pattern". Der Nutzer gibt an, welche Dateien Teil des GitHub-Releases sein sollen und das Kommando sorgt dafür, dass sie es sind. 

```
ci_tools update-github-release  --version-tag v2.0.0 \
                                --assets dist/bpmn-studio-setup-*.exe \
                                --assets dist/bpmn-studio-setup-*.exe.blockmap \
                                --assets dist/bpmn-studio-*-mac.zip \
                                --assets dist/bpmn-studio-*-x86_64.AppImage \
                                --assets dist/bpmn-studio-*.dmg \
                                --assets dist/bpmn-studio-*.dmg.blockmap \
                                --assets dist/latest-mac.yml \
                                --assets dist/latest.yml
```

Wie das Beispiel zeigt, müssen die Switches `title` und `text` nicht angegeben werden, so dass ein Release unter Angabe seines Versionstags leicht um Assets ergänzt werden kann (bspw. weil es die Paketierung/Distribution getrennter Schritt von der technischen GitHub-Release-Erstellung sein soll). 
