### PR TITLE
Add --except-on-primary-branches switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,9 +84,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+      "version": "12.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
       "dev": true
     },
     "@types/strip-bom": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.4",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.6.8",
+    "@types/node": "^12.6.9",
     "eslint": "^5.16.0",
     "mocha": "^6.1.4",
     "prettier": "^1.18.2",

--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -51,12 +51,17 @@ function run(argv: string[]): void {
     process.exit(1);
   }
 
-  enforceBranchGuard(commandName, args);
+  enforceUniversalCommandLineSwitches(commandName, args);
 
   foundCommand(...restArgs);
 }
 
-function enforceBranchGuard(commandName: string, args: string[]): void {
+function enforceUniversalCommandLineSwitches(commandName: string, args: string[]): void {
+  enforceOnlyOnPrimaryBranches(commandName, args);
+  enforceExceptOnPrimaryBranches(commandName, args);
+}
+
+function enforceOnlyOnPrimaryBranches(commandName: string, args: string[]): void {
   const runOnlyOnPrimaryBranches = args.includes('--only-on-primary-branches');
 
   if (!runOnlyOnPrimaryBranches) {
@@ -69,6 +74,24 @@ function enforceBranchGuard(commandName: string, args: string[]): void {
 
   if (!currentlyOnPrimaryBranch) {
     console.log(chalk.yellow(`${badge}--only-on-primary-branches given.`));
+    console.log(
+      chalk.yellow(`${badge}Current branch is '${branchName}' (primary branches are ${PRIMARY_BRANCHES.join(', ')}).`)
+    );
+    console.log(chalk.yellow(`${badge}Nothing to do here. Exiting.`));
+
+    process.exit(0);
+  }
+}
+
+function enforceExceptOnPrimaryBranches(commandName: string, args: string[]): void {
+  const runExceptOnPrimaryBranches = args.includes('--except-on-primary-branches');
+
+  const badge = `[${commandName}]\t`;
+  const branchName = getGitBranch();
+  const currentlyOnPrimaryBranch = PRIMARY_BRANCHES.includes(branchName);
+
+  if (runExceptOnPrimaryBranches && currentlyOnPrimaryBranch) {
+    console.log(chalk.yellow(`${badge}--except-on-primary-branches given.`));
     console.log(
       chalk.yellow(`${badge}Current branch is '${branchName}' (primary branches are ${PRIMARY_BRANCHES.join(', ')}).`)
     );


### PR DESCRIPTION
Führt das gegebene Kommando nur aus, wenn der User sich NICHT auf einem "primary branch"  (`develop`, `beta`, `master`) befindet.

```bash
$ ci_tools npm-install-only --except-on-primary-branches @process-engine/
```

Diese Option soll helfen auf Feature-Branches npm-Tags nutzen zu können, aber auf `develop`, `beta` und `master` ausschließlich `npm ci` laufen zu lassen.