### PR TITLE
🐛 Use 'save-exact' for 'npm-install-only'

### DIFF
--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -5,3 +5,15 @@ export function sh(command: string): string {
 
   return result.toString();
 }
+
+export function asyncSh(command: string): Promise<string> {
+  return new Promise((resolve: Function, reject: Function): void => {
+    shell.exec(command, { silent: true, async: true }, (code, stdout, stderr): void => {
+      if (code !== 0) {
+        return reject(new Error(stderr));
+      }
+
+      return resolve(stdout);
+    });
+  });
+}

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -8,7 +8,7 @@ const BADGE = '[npm-install-only]\t';
 export async function run(...args): Promise<boolean> {
   const isDryRun = args.indexOf('--dry') !== -1;
 
-  const allPackageNames = getAllPackageNames();
+  const allPackageNames = getAllPackageNamesWithVersion();
   const patternList = args.filter((arg: string): boolean => !arg.startsWith('-'));
   const foundPatternMatchingPackages = getPackageNamesMatchingPattern(allPackageNames, patternList);
   const npmInstallArguments = foundPatternMatchingPackages.join(' ');
@@ -52,12 +52,16 @@ function getPackageNamesMatchingPattern(allPackageNames: string[], patternList: 
   return foundPatternMatchingPackages;
 }
 
-function getAllPackageNames(): string[] {
+function getAllPackageNamesWithVersion(): string[] {
   const content = readFileSync('package.json').toString();
   const json = JSON.parse(content);
 
-  const dependencies: string[] = Object.keys(json.dependencies);
-  const devDependencies: string[] = Object.keys(json.devDependencies);
+  const dependencies: string[] = Object.keys(json.dependencies).map((dependency: string): string => {
+    return `${dependency}@${json.dependencies[dependency]}`;
+  });
+  const devDependencies: string[] = Object.keys(json.devDependencies).map((devDependency: string): string => {
+    return `${devDependency}@${json.devDependencies[devDependency]}`;
+  });
   const allPackageNames: string[] = [...dependencies].concat(devDependencies).sort();
 
   return allPackageNames;

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -20,7 +20,7 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`);
 
-  annotatedSh(`npm install --save-exact ${npmInstallArguments}`, isDryRun);
+  annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
 
   return true;
 }

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { readFileSync } from 'fs';
 
-import { sh } from '../cli/shell';
+import { asyncSh } from '../cli/shell';
 
 const BADGE = '[npm-install-only]\t';
 
@@ -34,13 +34,13 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`);
 
-  annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
-  annotatedSh(`npm install --save-exact ${npmInstallSaveExactArguments}`, isDryRun);
+  await annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
+  await annotatedSh(`npm install --save-exact ${npmInstallSaveExactArguments}`, isDryRun);
 
   return true;
 }
 
-function annotatedSh(command: string, isDryRun: boolean): void {
+async function annotatedSh(command: string, isDryRun: boolean): Promise<void> {
   console.log(`${BADGE}`);
   console.log(`${BADGE}Running: ${chalk.cyan(command)}`);
 
@@ -49,7 +49,7 @@ function annotatedSh(command: string, isDryRun: boolean): void {
     return;
   }
 
-  const output = sh(command);
+  const output = await asyncSh(command);
   console.log(output);
 }
 

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -20,7 +20,7 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`);
 
-  annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
+  annotatedSh(`npm install --save-exact ${npmInstallArguments}`, isDryRun);
 
   return true;
 }


### PR DESCRIPTION
**Changes:**

1. Use 'save-exact' for 'npm-install-only'

PR: #22

## How can others test the changes?

- **Have a look at [this pr](https://github.com/process-engine/process_engine_runtime/pull/392)**


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).