### PR TITLE
Fix identifying PRs for create-changelog

### DIFF
--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -12,6 +12,10 @@ export function getGitTagList(): string {
   return sh('git tag --sort=-creatordate').trim();
 }
 
+export function getGitCommitListSince(ref: string, since: string): string {
+  return sh(`git log --format="%H" --since ${since} ${ref}`).trim();
+}
+
 export function getGitCommitSha1(): string {
   return sh('git rev-parse HEAD').trim();
 }

--- a/src/github/pull_requests.ts
+++ b/src/github/pull_requests.ts
@@ -5,18 +5,20 @@ import { getCurrentApiBaseUrlWithAuth } from '../git/git';
 
 type PullRequestFromApi = any;
 export type PullRequest = {
-  hash: string;
-  mergedAt: string;
   number: number;
   title: string;
+  headSha: string;
+  mergeCommitSha: string;
+  mergedAt: string;
 };
 
 const PULL_REQUEST_INDEX_API_URI = getCurrentApiBaseUrlWithAuth('/pulls?state=closed');
 
 export async function getMergedPullRequests(since: string): Promise<PullRequest[]> {
   const list = await fetchPullRequests(since);
+  const listMergedBefore = list.filter((pr: PullRequest): boolean => !!pr.mergedAt);
 
-  return list.filter((pr: PullRequest): boolean => !!pr.mergedAt);
+  return listMergedBefore;
 }
 
 async function fetchPullRequests(since: string): Promise<PullRequest[]> {
@@ -24,7 +26,13 @@ async function fetchPullRequests(since: string): Promise<PullRequest[]> {
 
   return pullRequestsSince.map(
     (pr: PullRequestFromApi): PullRequest => {
-      return { hash: pr.merge_commit_sha, mergedAt: pr.merged_at, number: pr.number, title: pr.title };
+      return {
+        number: pr.number,
+        title: pr.title,
+        mergeCommitSha: pr.merge_commit_sha,
+        headSha: pr.head.sha,
+        mergedAt: pr.merged_at
+      };
     }
   );
 }

--- a/src/versions/previous_stable_version.test.ts
+++ b/src/versions/previous_stable_version.test.ts
@@ -15,6 +15,12 @@ v3.2.0`;
 
 describe('previous_stable_version.ts', (): void => {
   describe('previousVersion()', (): void => {
+    it('should return the previous version for the initial stable build', (): void => {
+      assert.equal(previousStableVersion('0.1.0', GIT_TAG_LIST), null);
+    });
+    it('should return the previous version for a stable build', (): void => {
+      assert.equal(previousStableVersion('2.0.0', GIT_TAG_LIST), '1.2.0');
+    });
     it('should return the previous version for the first alpha build of a new version', (): void => {
       assert.equal(previousStableVersion('3.2.1', GIT_TAG_LIST), '3.2.0');
     });


### PR DESCRIPTION
Uses the commit history to determine which PRs were merged (rather than a timestamp,
which breaks during feature-freeze).

Caveats: Does not pick up commits that were applied using `git cherry-pick`.