### PR TITLE
Add release channel comparison to prepare-version

### DIFF
--- a/src/commands/prepare-version.ts
+++ b/src/commands/prepare-version.ts
@@ -50,9 +50,13 @@ export async function run(...args): Promise<boolean> {
   const nextVersion = getNextVersion();
   const nextVersionTag = getVersionTag(nextVersion);
 
+  const currentVersionReleaseChannel = getReleaseChannelFromTag(currentVersionTag);
+  const nextVersionReleaseChannel = getReleaseChannelFromTag(nextVersionTag);
+  const isSameReleaseChannel = currentVersionReleaseChannel === nextVersionReleaseChannel;
+
   printInfo(nextVersion, isDryRun, isForced);
 
-  if (isCurrentTag(currentVersionTag)) {
+  if (isSameReleaseChannel && isCurrentTag(currentVersionTag)) {
     console.error(
       chalk.yellow(
         `${BADGE}Current commit is tagged with "${currentVersionTag}", which is the current package version.`
@@ -133,4 +137,10 @@ function printInfo(nextVersion: string, isDryRun: boolean, isForced: boolean): v
   printMultiLineString(getGitTagsFromCommit('HEAD'));
   console.log(`${BADGE}nextVersionTag:`, getVersionTag(nextVersion));
   console.log('');
+}
+
+function getReleaseChannelFromTag(tagName: string): string {
+  const matched = tagName.match(/^v\d+\.\d+\.\d+-([^.]+)/);
+
+  return matched == null ? null : matched[0];
 }


### PR DESCRIPTION
Wenn man aktuell von bspw. `beta` nach `master` mergt, um aus Version `2.0.0-beta.1` die Version `2.0.0` zu machen, dann brechen die CI Tools ab, weil sie denken "Da sind keine Änderungen im Vergleich zu `2.0.0-beta.1`, also brechen wir hier mal ab.".

Die Änderungen dieses PRs bedingen einen Vergleich des Release-Kanals, um festzustellen, ob trotz gleicher Inhalte eine neue Version gebaut werden muss.
