### PR TITLE
Feature/add command fail on pre version dependencies

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -6,18 +6,19 @@ import * as yargsParser from 'yargs-parser';
 import { run as runAutoPublishIfApplicable } from './commands/internal/auto-publish-if-applicable';
 import { run as runCommitAndTagVersion } from './commands/commit-and-tag-version';
 import { run as runCreateChangelog } from './commands/internal/create-changelog';
+import { run as runFailOnPreVersionDependencies } from './commands/fail-on-pre-version-dependencies';
 import { run as runNpmInstallOnly } from './commands/npm-install-only';
 import { run as runPrepareVersion } from './commands/prepare-version';
+import { run as runPublishNpmPackage } from './commands/publish-npm-package';
 import { run as runSetupGitAndNpmConnections } from './commands/internal/setup-git-and-npm-connections';
 import { run as runUpdateGithubRelease } from './commands/update-github-release';
 
 import { getGitBranch } from './git/git';
 import { PRIMARY_BRANCHES } from './versions/increment_version';
 
-import { run as runPublishNpmPackage } from './commands/publish-npm-package';
-
 const COMMAND_HANDLERS = {
   'commit-and-tag-version': runCommitAndTagVersion,
+  'fail-on-pre-version-dependencies': runFailOnPreVersionDependencies,
   'prepare-version': runPrepareVersion,
   'publish-npm-package': runPublishNpmPackage,
   'npm-install-only': runNpmInstallOnly,
@@ -28,7 +29,6 @@ const COMMAND_HANDLERS = {
 const INTERNAL_COMMAND_HANDLERS = {
   'auto-publish-if-applicable': runAutoPublishIfApplicable,
   'create-changelog': runCreateChangelog,
-  'npm-install-only': runNpmInstallOnly,
   'update-github-release': runUpdateGithubRelease,
   'setup-git-and-npm-connections': runSetupGitAndNpmConnections
 };

--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -70,6 +70,23 @@ function enforceUniversalCommandLineSwitches(commandName: string, args: string[]
   } else if (argv.exceptOnPrimaryBranches) {
     ensureNotOnPrimaryBranchOrExit(badge);
   }
+
+  if (argv.onlyOnBranch) {
+    ensureOnBranchOrExit(badge, argv.onlyOnBranch);
+  }
+}
+
+function ensureOnBranchOrExit(badge: string, requestedBranchName: string): void {
+  const branchName = getGitBranch();
+  const currentlyOnBranch = requestedBranchName === branchName;
+
+  if (!currentlyOnBranch) {
+    console.log(chalk.yellow(`${badge}--only-on-branch given: ${requestedBranchName}`));
+    console.log(chalk.yellow(`${badge}Current branch is '${branchName}'.`));
+    console.log(chalk.yellow(`${badge}Nothing to do here. Exiting.`));
+
+    process.exit(0);
+  }
 }
 
 function ensureOnPrimaryBranchOrExit(badge: string): void {

--- a/src/commands/fail-on-pre-version-dependencies.ts
+++ b/src/commands/fail-on-pre-version-dependencies.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs';
+
+import chalk from 'chalk';
+
+const BADGE = '[fail-on-pre-version-dependencies]\t';
+
+/**
+ * Fails if there are any requirements containing pre-versions in `package.json`.
+ */
+export async function run(...args): Promise<boolean> {
+  const content = readFileSync('package.json').toString();
+  const json = JSON.parse(content);
+
+  const dependencies = Object.assign({}, json.dependencies, json.devDependencies);
+
+  const dependenciesWithPreVersions = Object.keys(dependencies).filter((packageName: string): boolean => {
+    const version = dependencies[packageName];
+    const isPreVersion = version.indexOf('-') !== -1;
+
+    return isPreVersion;
+  });
+
+  if (dependenciesWithPreVersions.length > 0) {
+    console.error(chalk.red(`${BADGE}Found dependencies with pre-version requirements:`));
+    console.error(chalk.red(`${BADGE}`));
+
+    dependenciesWithPreVersions.forEach((packageName: string): void => {
+      console.error(chalk.red(`${BADGE}  - ${packageName}@${dependencies[packageName]}`));
+    });
+
+    process.exit(1);
+  }
+
+  return true;
+}

--- a/src/commands/fail-on-pre-version-dependencies.ts
+++ b/src/commands/fail-on-pre-version-dependencies.ts
@@ -15,9 +15,9 @@ export async function run(...args): Promise<boolean> {
 
   const dependenciesWithPreVersions = Object.keys(dependencies).filter((packageName: string): boolean => {
     const version = dependencies[packageName];
-    const isPreVersion = version.indexOf('-') !== -1;
+    const isPreVersionOrDistTag = version.indexOf('-') !== -1 || version.indexOf('~') > 0;
 
-    return isPreVersion;
+    return isPreVersionOrDistTag;
   });
 
   if (dependenciesWithPreVersions.length > 0) {


### PR DESCRIPTION
Fügt ein Kommando hinzu, das abbricht, wenn noch Pre-Versions in `dependencies` oder `devDependencies` stehen:

```
[fail-on-pre-version-dependencies]	Found dependencies with pre-version requirements:
[fail-on-pre-version-dependencies]
[fail-on-pre-version-dependencies]	  - @essential-projects/eslint-config@^1.0.4-some-pre-version
```