### PR TITLE
✨ Make ci_tools work for retried builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/ci_tools",
-  "version": "2.1.0-pre",
+  "version": "2.2.0-pre",
   "description": "CI tools for process-engine.io",
   "main": "dist/ci_tools.js",
   "scripts": {

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -1,18 +1,14 @@
 import * as shell from 'shelljs';
 
 export function sh(command: string): string {
-  const result = shell.exec(command, { silent: true });
+  const result = shell.exec(`${command} 2>&1`, { silent: true });
 
-  return result.toString();
+  return result.stdout;
 }
 
 export function asyncSh(command: string): Promise<string> {
   return new Promise((resolve: Function, reject: Function): void => {
-    shell.exec(command, { silent: true, async: true }, (code, stdout, stderr): void => {
-      if (code !== 0) {
-        return reject(new Error(stderr));
-      }
-
+    shell.exec(`${command} 2>&1`, { silent: true, async: true }, (code, stdout, stderr): void => {
       return resolve(stdout);
     });
   });

--- a/src/commands/commit-and-tag-version.ts
+++ b/src/commands/commit-and-tag-version.ts
@@ -6,6 +6,7 @@ import { getPackageVersion, getPackageVersionTag } from '../versions/package_ver
 import { getPrevVersionTag } from '../versions/git_helpers';
 import { setupGit } from './internal/setup-git-and-npm-connections';
 import { sh } from '../cli/shell';
+import { isRetryRun } from '../versions/retry_run';
 
 const BADGE = '[commit-and-tag-version]\t';
 
@@ -21,6 +22,20 @@ export async function run(...args): Promise<boolean> {
   setupGit();
 
   printInfo(isDryRun, isForced);
+
+  if (isRetryRun()) {
+    const currentVersionTag = getPackageVersionTag();
+
+    console.error(
+      chalk.yellow(
+        `${BADGE}Current commit is tagged with "${currentVersionTag}", which is the current package version.`
+      )
+    );
+
+    console.error(chalk.yellowBright(`${BADGE}Nothing to do here!`));
+
+    process.exit(0);
+  }
 
   const packageVersion = getPackageVersion();
   const changelogText = await getChangelogText(getPrevVersionTag());

--- a/src/versions/retry_run.ts
+++ b/src/versions/retry_run.ts
@@ -1,0 +1,23 @@
+import { getPackageVersionTag } from './package_version';
+import { getNextVersion, getVersionTag } from './git_helpers';
+import { isCurrentTag } from '../git/git';
+
+export function isRetryRun(): boolean {
+  const currentVersionTag = getPackageVersionTag();
+  const nextVersion = getNextVersion();
+  const nextVersionTag = getVersionTag(nextVersion);
+
+  const currentVersionReleaseChannel = getReleaseChannelFromTagOrVersion(currentVersionTag);
+  const nextVersionReleaseChannel = getReleaseChannelFromTagOrVersion(nextVersionTag);
+  const isSameReleaseChannel = currentVersionReleaseChannel === nextVersionReleaseChannel;
+
+  const result = isSameReleaseChannel && isCurrentTag(currentVersionTag);
+
+  return result;
+}
+
+function getReleaseChannelFromTagOrVersion(tagNameOrVersion: string): string {
+  const matched = tagNameOrVersion.match(/^v?\d+\.\d+\.\d+-([^.]+)/);
+
+  return matched == null ? null : matched[0];
+}


### PR DESCRIPTION
Soll dafür sorgen, dass ein wiederholter CI Build Job bzgl. der nicht erfolgreich ausgeführten Steps wiederholt wird und an allen anderen Steps *nicht* scheitert.