### PR TITLE
Add upgrade-dependencies-with-pre-versions command

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -12,6 +12,7 @@ import { run as runPrepareVersion } from './commands/prepare-version';
 import { run as runPublishNpmPackage } from './commands/publish-npm-package';
 import { run as runSetupGitAndNpmConnections } from './commands/internal/setup-git-and-npm-connections';
 import { run as runUpdateGithubRelease } from './commands/update-github-release';
+import { run as runUpgradeDependenciesWithPreVersions } from './commands/upgrade-dependencies-with-pre-versions';
 
 import { getGitBranch } from './git/git';
 import { PRIMARY_BRANCHES } from './versions/increment_version';
@@ -22,7 +23,8 @@ const COMMAND_HANDLERS = {
   'prepare-version': runPrepareVersion,
   'publish-npm-package': runPublishNpmPackage,
   'npm-install-only': runNpmInstallOnly,
-  'update-github-release': runUpdateGithubRelease
+  'update-github-release': runUpdateGithubRelease,
+  'upgrade-dependencies-with-pre-versions': runUpgradeDependenciesWithPreVersions
 };
 
 // Internal commands are only used to develop ci_tools and are not intended for public consumption.

--- a/src/commands/upgrade-dependencies-with-pre-versions.test.ts
+++ b/src/commands/upgrade-dependencies-with-pre-versions.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import { getVersionToUpgradeTo } from './upgrade-dependencies-with-pre-versions';
+
+const VERSION_LIST = [
+  '1.2.1-alpha.7',
+  '1.2.1-alpha.8',
+  '1.2.1-alpha.9',
+  '2.0.0-alpha.1',
+  '2.0.0-alpha.2',
+  '2.0.0-alpha.3',
+  '2.0.0-beta.1',
+  '2.0.0-beta.2',
+  '2.0.0',
+  '2.1.0-beta.1'
+];
+
+describe('upgrade-dependencies-with-pre-versions.ts', (): void => {
+  describe('getVersionToUpgradeTo()', (): void => {
+    it('should work as expected for beta requirements', (): void => {
+      assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-beta.1', VERSION_LIST), null);
+      assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0-beta.1', VERSION_LIST), '2.0.0');
+      assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0-beta.2', VERSION_LIST), '2.0.0');
+    });
+
+    it('should work as expected for stable requirements', (): void => {
+      assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1', VERSION_LIST), null);
+      assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0', VERSION_LIST), null);
+      assert.deepStrictEqual(getVersionToUpgradeTo('2.1.0', VERSION_LIST), null);
+    });
+
+    it('should work as expected for alpha requirements', (): void => {
+      assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-alpha.9', VERSION_LIST), null);
+      assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-alpha.8', VERSION_LIST), '1.2.1-alpha.9');
+    });
+  });
+});

--- a/src/commands/upgrade-dependencies-with-pre-versions.ts
+++ b/src/commands/upgrade-dependencies-with-pre-versions.ts
@@ -1,0 +1,189 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+
+import { asyncSh, sh } from '../cli/shell';
+import { parseVersion } from '../versions/parse_version';
+
+const BADGE = '[upgrade-dependencies-with-pre-versions]\t';
+
+type Pattern = string | RegExp;
+
+/**
+ * Upgrades alpha- and beta-pre-versions for the packages with a name starting with one of the given args.
+ *
+ * Example:
+ *
+ *    ci_tools upgrade-dependencies-with-pre-versions @process-engine/
+ *
+ * Upgrades all deps starting with `@process-engine/` if there is a newer version available in their
+ * release channel or if a stable version of the same base version has been released.
+ *
+ * This command does not change base version!
+ */
+export async function run(...args): Promise<boolean> {
+  const isDryRun = args.indexOf('--dry') !== -1;
+  const patternList = args.filter((arg: string): boolean => !arg.startsWith('-'));
+
+  const dependencies = getAllDependencies();
+  const dependenciesFilteredByName = filterDependenciesByName(dependencies, patternList);
+  const dependenciesFilteredByRequirement = filterDependenciesByRequirement(dependencies, [/-(alpha|beta)\./]);
+
+  console.log(`${BADGE}patternList:`, patternList);
+  console.log(`${BADGE}dependenciesFilteredByName:`, dependenciesFilteredByName);
+  console.log(`${BADGE}dependenciesFilteredByRequirement:`, dependenciesFilteredByRequirement);
+
+  const versionsToInstall = [];
+  Object.keys(dependenciesFilteredByRequirement).forEach((packageName: string): void => {
+    const requirement = dependenciesFilteredByRequirement[packageName];
+    const parsedRequirement = parseVersion(requirement);
+
+    if (parsedRequirement == null) {
+      return;
+    }
+
+    const output = sh(`npm view ${packageName} --json`);
+    let json = null;
+    try {
+      json = JSON.parse(output);
+    } catch (e) {
+      console.error('Parsing result from npm view did not work:');
+      console.error(e);
+    }
+
+    if (json != null) {
+      const allPackageVersions = json.versions;
+
+      const versionUpgradeTo = getVersionToUpgradeTo(requirement, allPackageVersions);
+      if (versionUpgradeTo) {
+        versionsToInstall.push(`${packageName}@${versionUpgradeTo}`);
+      }
+    }
+  });
+
+  console.log('versionsToInstall', versionsToInstall);
+
+  await annotatedSh(`npm install --save-exact ${versionsToInstall.join(' ')}`, isDryRun);
+
+  return true;
+}
+
+export function getVersionToUpgradeTo(requirement: string, versions: string[]): string | null {
+  const parsedRequirement = parseVersion(requirement);
+  if (parsedRequirement == null) {
+    return null;
+  }
+
+  const versionsWithSameBaseVersion = getVersionsWithSameBaseVersion(requirement, versions);
+
+  let upgradeToVersion = null;
+
+  if (parsedRequirement.releaseChannelNumber != null) {
+    let currentParsedVersion = parsedRequirement;
+
+    versionsWithSameBaseVersion.forEach((versionString: string): void => {
+      const parsedVersion = parseVersion(versionString);
+      const hasGreaterNumber =
+        parsedVersion.releaseChannelNumber != null &&
+        parsedVersion.releaseChannelNumber > currentParsedVersion.releaseChannelNumber;
+
+      if (hasGreaterNumber) {
+        upgradeToVersion = versionString;
+        currentParsedVersion = parsedVersion;
+      }
+    });
+  }
+
+  const exactMatchForBaseVersion = versionsWithSameBaseVersion.find(
+    (versionString: string): boolean => versionString === parsedRequirement.baseString
+  );
+
+  if (exactMatchForBaseVersion != null) {
+    upgradeToVersion = exactMatchForBaseVersion;
+  }
+
+  return upgradeToVersion === requirement ? null : upgradeToVersion;
+}
+
+function getVersionsWithSameBaseVersion(requirement: string, versions: string[]): string[] {
+  const parsedRequirement = parseVersion(requirement);
+
+  return versions.filter((versionString: string): boolean => {
+    const parsedVersion = parseVersion(versionString);
+    if (parsedVersion == null) {
+      return false;
+    }
+
+    const isSameBaseVersion = parsedVersion.baseString === parsedRequirement.baseString;
+    const isStableVersion = parsedVersion.releaseChannelName === 'stable';
+    const isSameReleaseChannel = parsedVersion.releaseChannelName === parsedRequirement.releaseChannelName;
+    const hasNoNumber = parsedVersion.releaseChannelNumber == null;
+    const hasGreaterNumber =
+      parsedVersion.releaseChannelNumber != null &&
+      parsedVersion.releaseChannelNumber > parsedRequirement.releaseChannelNumber;
+
+    return (
+      parsedVersion != null &&
+      isSameBaseVersion &&
+      (isStableVersion || isSameReleaseChannel) &&
+      (hasNoNumber || hasGreaterNumber)
+    );
+  });
+}
+
+function filterDependenciesByName(dependencyObject: any, patternList: Pattern[]): any {
+  const result = {};
+  Object.keys(dependencyObject).forEach((packageName: string): void => {
+    const patternMatched = matchesPatternList(packageName, patternList);
+    if (patternMatched) {
+      result[packageName] = dependencyObject[packageName];
+    }
+  });
+  return result;
+}
+
+function filterDependenciesByRequirement(dependencyObject: any, patternList: Pattern[]): any {
+  const result = {};
+  Object.keys(dependencyObject).forEach((packageName: string): void => {
+    const requirement = dependencyObject[packageName];
+    const patternMatched = matchesPatternList(requirement, patternList);
+    if (patternMatched) {
+      result[packageName] = requirement;
+    }
+  });
+  return result;
+}
+
+function matchesPatternList(value: string, patternList: Pattern[]): boolean {
+  return patternList.some((pattern: Pattern): boolean => {
+    if (typeof pattern === 'string') {
+      return value.startsWith(pattern);
+    }
+
+    return value.match(pattern) != null;
+  });
+}
+
+function getAllDependencies(): any {
+  const packageJson = getPackageJson();
+  const allPackages = Object.assign({}, packageJson.dependencies, packageJson.devDependencies);
+  return allPackages;
+}
+
+function getPackageJson(): any {
+  const content = readFileSync('package.json').toString();
+  const json = JSON.parse(content);
+  return json;
+}
+
+async function annotatedSh(command: string, isDryRun: boolean): Promise<void> {
+  console.log(`${BADGE}`);
+  console.log(`${BADGE}Running: ${chalk.cyan(command)}`);
+
+  if (isDryRun) {
+    console.log(chalk.yellow('\n  [skipping execution due to --dry]\n'));
+    return;
+  }
+
+  const output = await asyncSh(command);
+  console.log(output);
+}

--- a/src/versions/parse_version.test.ts
+++ b/src/versions/parse_version.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import { parseVersion } from './parse_version';
+
+describe('parse_version.ts', (): void => {
+  describe('parseVersion()', (): void => {
+    it('should return null for dist-tags', (): void => {
+      assert.deepStrictEqual(parseVersion('alpha'), null);
+    });
+
+    it('should work as expected for stable versions', (): void => {
+      const input = '2.2.0';
+      const expected = {
+        baseString: '2.2.0',
+        releaseChannelName: 'stable'
+      };
+      assert.deepStrictEqual(parseVersion(input), expected);
+    });
+
+    it('should work as expected for alpha versions', (): void => {
+      const input = '2.2.0-alpha.5';
+      const expected = {
+        baseString: '2.2.0',
+        releaseChannelName: 'alpha',
+        releaseChannelNumber: 5
+      };
+      assert.deepStrictEqual(parseVersion(input), expected);
+    });
+
+    it('should work as expected for beta versions', (): void => {
+      const input = '0.2.0-beta.8';
+      const expected = {
+        baseString: '0.2.0',
+        releaseChannelName: 'beta',
+        releaseChannelNumber: 8
+      };
+      assert.deepStrictEqual(parseVersion(input), expected);
+    });
+
+    it('should return null as releaseChannel for unknown pre-version suffixes', (): void => {
+      const input = '3.2.1-asdf5';
+      const expected = null;
+      assert.deepStrictEqual(parseVersion(input), expected);
+    });
+  });
+});

--- a/src/versions/parse_version.ts
+++ b/src/versions/parse_version.ts
@@ -1,0 +1,47 @@
+export type ParsedVersion = {
+  baseString: string;
+  releaseChannelName: string;
+  releaseChannelNumber?: number;
+};
+
+type ReleaseChannelInfo = {
+  name: string;
+  number?: number;
+};
+
+const RELEASE_CHANNEL_NAME_STABLE = 'stable';
+
+export function parseVersion(version: string): ParsedVersion {
+  const isSemVer = version.match(/^\d+\.\d+\.\d+/) != null;
+  if (!isSemVer) {
+    return null;
+  }
+
+  const isPreVersion = version.includes('-');
+
+  if (isPreVersion) {
+    const parts = version.split('-');
+    const baseString = parts[0];
+    const releaseChannelString = parts[1];
+
+    const isNumberedReleaseChannel = releaseChannelString.includes('.');
+    if (!isNumberedReleaseChannel) {
+      return null;
+    }
+
+    const releaseChannelParts = releaseChannelString.split('.');
+    const releaseChannelName = releaseChannelParts[0];
+    const releaseChannelNumber = parseInt(releaseChannelParts[1]);
+
+    return {
+      baseString: baseString,
+      releaseChannelName: releaseChannelName,
+      releaseChannelNumber: releaseChannelNumber
+    };
+  }
+
+  return {
+    baseString: version,
+    releaseChannelName: RELEASE_CHANNEL_NAME_STABLE
+  };
+}


### PR DESCRIPTION
Aus der Doku:

> Upgrades alpha- and beta-pre-versions for the packages with a name starting with one of the given args.
>
> Example:
>
>      ci_tools upgrade-dependencies-with-pre-versions @process-engine/
>
> Upgrades all deps starting with `@process-engine/` if there is a newer version available in their
> release channel or if a stable version of the same base version has been released.
>
> This command does not change base version!

Dieses Programm ist nur für das "Anheben der Nummer bei Pre-Releases" bzw. das Upgrade auf die entsprechende stabile Version zuständig.

Der automatische Wechsel der Dependency-Einträge von Alpha auf Beta ist nicht Gegenstand *dieses* PRs.