### PR TITLE
✨ Implement retry for publish-npm-package

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,42 +1,69 @@
-#### Describe your issue
+## BEFORE SUBMITTING
 
-> Describe the issue or ask your question regarding this module.
-> Provide as much relevant information as you can. If you're not sure if something
-> is relevant or not, include it as well!
-> 
-> Logs and screenshots are very welcome!
-
-#### How can others reproduce the issue?
-
-> Describe how others can reproduce this issue as precisely as possible.
-> 
-> If you can't reproduce the issue, let us know what you tried!
-> 
-> You can remove this section if the issue isn't something reproducable
-> (for example for certain questions or feature requests).
-
-#### Possible solution
-
-> If you have a possible solution to this issue or an idea that might
-> help us to find one, describe it here. Let us know what you tried!
+> **Please ensure you have followed this guide, _before_ submitting your issue!**
 >
-> You can remove this section if it'd be empty.
+> - Check if this issue already exists (including closed issues!)
+> - Prefix the issue title according to the [gitmoji guide](https://gitmoji.carloscuesta.me/)
+> - Reference all PRs and issues related to this one
+>
+><details>
+><summary>
+>Click here for a list of commonly used issue emojis.
+></summary>
+>
+>| Description              | Glyphe                      | Emoji|
+>|--------------------------|-----------------------------|------|
+>| Bugfix                   | `:bug:`                     | 🐛   |
+>| Fixing Security issues   | `:lock:`                    | 🔒   |
+>| Improving Performance    | `:zap:`                     | ⚡️   |
+>| New Feature              | `:sparkles:`                | ✨   |
+>| Refactoring Code         | `:recycle:`                 | ♻️   |
+>| CI Pipeline related      | `:construction_worker_man:` | 👷   |
+>| Configuration releated   | `:wrench:`                  | 🔧   |
+>| Tests                    | `:white_check_mark:`        | ✅   |
+>| Removing Stuff           | `:fire:`                    | 🔥   |
+>| Dependencies Downgrade   | `:arrow_down:`              | ⬇️   |
+>| Dependencies Upgrade     | `:arrow_up:`                | ⬆️   |
+>| Linter                   | `:rotating_light:`          | 🚨   |
+>| Cosmetic                 | `:lipstick:`                | 💄   |
+>| Miscellaneous            | `:package:`                 | 📦   |
+>
+></details>
+>
+> **Please remove this section when you're done creating this issue.**
 
-#### What's your setup
+## Description
+
+> Describe your issue/question here.
+>
+> Provide as much relevant information as you can.
+> If you're not sure if something is relevant or not, include it as well!
+>
+>**If this is a feature request, please give a short summary as to what you need it for!**
+
+## Reproduction
+
+> You can remove this section, if the issue isn't something that requires reproducton.
+>
+> Describe how others can reproduce this issue as precisely as possible.
+>
+> If you can't reproduce the issue, let us know what you tried!
+>
+> Logs, Screenshots and BPMN files are always helpful!
+
+## Possible solution
+
+> This section is usually only required when reporting bugs.
+> So you can remove it, if this issue is not something that needs solving.
+>
+> Of course, if you make a feature request and already have an idea on how
+> to implement it, you are welcome to describe your proposed solution here as well!
+
+## My setup
+
+> You can remove this section, if it's irrelevant to the issue
 
 - OS (`Windows/OS X/Linux` + `version`):
 - Node (`node --version`):
 - NPM (`npm --version`):
 - Docker (`docker version --format '{{.Server.Version}}'`):
-
-> You can remove this section if it's irrelevant to the issue
-> (for example for certain questions or feature requests).
-
-#### Issue checklist
-
-Please check the boxes in this list after submitting your Issue:
-
-- [ ] I've checked if this issue already exists
-- [ ] I've included all the information that i think is relevant
-- [ ] I've added logs and/or screenshots (if applicable)
-- [ ] I've mentioned PRs and issues that relate to this one

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,119 +1,59 @@
-:tada: **Thanks for submitting this Pull Request**
+## BEFORE SUBMITTING
 
-Please provide a list including your changes.
+> **Please ensure you have followed this guide, _before_ submitting your PR!**
+>
+> - Prefix the PR title according to the [gitmoji guide](https://gitmoji.carloscuesta.me/).
+> - Reference all PRs and issues relevant for this PR.
+> - **Be sure that you have reviewed and tested every change you made here!**
+>     - If you're not sure how you can test your changes, don't hesitate to contact us!
+> - List all fixed/closed issues here with `Closes #123` or `Fixes #123`.
+>     - **If no issue for this PR exists, please consider creating one!**
+>     - Of course, if this just fixes a typo, linter error or is something equally simple, no issue is required.
+> - Add the number of this PR to this PRs body, so you can add it to the commit message.
+> This will allow us to create a nice changelog for the next release.
+>
+><details>
+><summary>
+>Click here for a list of commonly used PR emojis.
+></summary>
+>
+>| Description              | Glyphe                      | Emoji|
+>|--------------------------|-----------------------------|------|
+>| Work In Progress (WIP)   | `:construction:`            | 🚧   |
+>| Bugfix                   | `:bug:`                     | 🐛   |
+>| Fixing Security Issues   | `:lock:`                    | 🔒   |
+>| Improving Performance    | `:zap:`                     | ⚡️   |
+>| New Feature              | `:sparkles:`                | ✨   |
+>| Refactoring Code         | `:recycle:`                 | ♻️   |
+>| CI Pipeline related      | `:construction_worker_man:` | 👷   |
+>| Configuration releated   | `:wrench:`                  | 🔧   |
+>| Tests                    | `:white_check_mark:`        | ✅   |
+>| Removing Stuff           | `:fire:`                    | 🔥   |
+>| Releasing / Version tags | `:bookmark:`                | 🔖   |
+>| Dependencies Downgrade   | `:arrow_down:`              | ⬇️   |
+>| Dependencies Upgrade     | `:arrow_up:`                | ⬆️   |
+>| Initial commit           | `:tada:`                    | 🎉   |
+>| Linter                   | `:rotating_light:`          | 🚨   |
+>| Cosmetic                 | `:lipstick:`                | 💄   |
+>| Formatting               | `:art:`                     | 🎨   |
+>| Miscellaneous            | `:package:`                 | 📦   |
+>
+></details>
+>
+> **Please remove this section when you're done creating this PR.**
 
-To help us to create a meaningful Changelog, we agreed
-to use an emoji-based commit-style. Use the [Emojis](#emojis)
-we provided below.
-
-Fill out the following, provide reference to issues
-and this PR- we will use this as merge commit message-body
-and the title of this PR as commit-headline:
-
----
-
-**Changes:**
+## Changes
 
 1. Change 1
 2. Change 2
 3. (...)
 
+## Issues
 
-**Issues:**
-
-Closes #Issue
-Closes #Issue
-Closes (...)
-
-PR: #PullRequest
-
----
-
-See the [examples](#example) for inspiration.
-
-## How can others test the changes?
-
-> Describe how others can test your changes (you can remove this section for typo fixes etc.)
-
-## PR-Checklist
-
-Please check the boxes in this list after submitting your PR:
-
-- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
-- [x] I've tested **all** changes included in this PR.
-- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
-- [x] I've rebased the `develop` branch with my branch before finishing this PR.
-- [x] I've **summarized all changes** in a list above.
-- [x] I've mentioned all **PRs, which relate to this one**.
-- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
-
-## Example
-
-<details>
-<summary>
-:warning: Before merging please click here to expand and follow the guide.
-</summary>
-<br>
-
-Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.
-
-Example 1:
-
-<pre>
-<code>
-:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
-</code>
-</pre>
-
-To get your commit message, just copy the first part of this pull request.
-
-Example 2:
-<pre>
-<code>
-**Changes:**
-
-- Fixes Wrong Text Decoration at ...
-- Fixes some typos
-- ...
-
-**Issues:**
-
-Closes #NumberOfFixedIssue
+Closes #YourIssueNumber
 
 PR: #NumberOfThisPR
-</code>
-</pre>
-</details>
 
-## Emojis
+## How to test the changes
 
-<details>
-<summary>
-Expand for a list of most used Emojis.
-</summary>
-<br>
-
-Please prefix your commit messages with an Emoji.
-
-Ref: https://gitmoji.carloscuesta.me/
-
-| Description              | Glyphe               | Emoji  |
-|--------------------------|----------------------|--------|
-| Bugfix                   | `:bug:`              | 🐛     |
-| Configuration releated   | `:wrench:`           | 🔧     |
-| Cosmetic                 | `:lipstick:`         | 💄     |
-| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
-| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
-| Formatting               | `:art:`              | 🎨     |
-| Improving Performance    | `:zap:`              | ⚡️     |
-| Initial commit           | `:tada:`             | 🎉     |
-| Linter                   | `:rotating_light:`   | 🚨     |
-| Miscellaneous            | `:package:`          | 📦     |
-| New Feature              | `:sparkles:`         | ✨     |
-| Refactoring Code         | `:recycle:`          | ♻️     |
-| Releasing / Version tags | `:bookmark:`         | 🔖     |
-| Removing Stuff           | `:fire:`             | 🔥     |
-| Tests                    | `:white_check_mark:` | ✅     |
-| Work In Progress (WIP)   | `:construction:`     | 🚧     |
-
-</details>
+> Describe how others can test your changes (not required when fixing typos, linter errors and such)

--- a/src/commands/publish-npm-package.ts
+++ b/src/commands/publish-npm-package.ts
@@ -106,6 +106,7 @@ async function ensureVersionIsAvailable(packageName: string, packageVersion: str
     if (packageVersionFound) {
       break;
     } else {
+      console.log(chalk.yellow(`${BADGE}Version '${packageVersion}' not found. Retrying in 500ms...`));
       currentTry++;
       await new Promise((resolve): any => setTimeout(resolve, timeoutBetweenRetriesInMs));
     }

--- a/src/commands/publish-npm-package.ts
+++ b/src/commands/publish-npm-package.ts
@@ -38,17 +38,7 @@ export async function run(...args): Promise<boolean> {
   const publishCommandSuccessful = lines[lines.length - 1] === expectedMessage;
 
   if (publishCommandSuccessful) {
-    const viewCommand = `npm view ${packageName} versions --json`;
-    const versions = sh(viewCommand);
-    const packageWasActuallyPublished = versions.includes(packageVersion);
-
-    if (packageWasActuallyPublished) {
-      console.log(chalk.green(`${BADGE}Successfully published version '${packageVersion}'.`));
-    } else {
-      console.error(chalk.red(`${BADGE}Version '${packageVersion}' is not reported by '${viewCommand}'.`));
-
-      process.exit(1);
-    }
+    await ensureVersionIsAvailable(packageName, packageVersion);
   } else {
     const isAlreadyPublished =
       npmPublishShellCommandOutput.match(/You cannot publish over the previously published versions/gi) != null;
@@ -92,9 +82,40 @@ function annotatedSh(cmd: string): string {
   return output;
 }
 
-function getPackageName(): string[] {
+function getPackageName(): string {
   const content = readFileSync('package.json').toString();
   const json = JSON.parse(content);
 
   return json.name;
+}
+
+async function ensureVersionIsAvailable(packageName: string, packageVersion: string): Promise<void> {
+
+  const viewCommand = `npm view ${packageName} versions --json`;
+  let packageVersionFound = false;
+
+  // TODO: It is certainly debatable on what the best settings would be here.
+  const maxNumberOfRetries = 20;
+  const timeoutBetweenRetriesInMs = 500;
+  let currentTry = 0;
+
+  while (packageVersionFound === false && currentTry < maxNumberOfRetries) {
+    const versions = sh(viewCommand);
+    packageVersionFound = versions.includes(packageVersion);
+
+    if (packageVersionFound) {
+      break;
+    } else {
+      currentTry++;
+      await new Promise((resolve): any => setTimeout(resolve, timeoutBetweenRetriesInMs));
+    }
+  }
+
+  if (packageVersionFound) {
+    console.log(chalk.green(`${BADGE}Successfully published version '${packageVersion}'.`));
+  } else {
+    console.error(chalk.red(`${BADGE}Version '${packageVersion}' is not reported by 'npm view'.`));
+
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Changes

Implement `retry` for `publish-npm-package` command version verification.

This retry will run the follow-up `npm view` command up to 20 times, with a timeout of 500ms between each try.

If the max number of retries is used up and the package is still not visible at npm, the publish is regarded as a failure.

## Issues

PR: #33

## How to test the changes

Unfortunately, this can only be tested when npm is hanging again. 

If that is the case, the published version would not be initially visible.
Normally, the command would immediately throw an error, but with the retry-loop in place, it will now retry a number of times, before giving up.
Each retry should be visible in the console.