### PR TITLE
Fix injection possibility through commit messages

### DIFF
--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -13,3 +13,7 @@ export function asyncSh(command: string): Promise<string> {
     });
   });
 }
+
+export function escapeForShell(text: string): string {
+  return text.replace(/(`|\$|")/g, '\\$1');
+}

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -1,4 +1,4 @@
-import { sh } from '../cli/shell';
+import { escapeForShell, sh } from '../cli/shell';
 
 const CURRENT_BRANCH_MARKER = /^\* /;
 
@@ -82,7 +82,7 @@ export function gitAdd(...files: string[]): GitOperationResult {
 }
 
 export function gitCommit(commitMessage: string): GitOperationResult {
-  const escapedCommitMessage = commitMessage.replace(/"/g, '\\"');
+  const escapedCommitMessage = escapeForShell(commitMessage);
 
   return sh(`git commit -m "${escapedCommitMessage}"`);
 }


### PR DESCRIPTION
Sorgt dafür, dass Commit Messages mit Backticks escaped werden (damit sie nicht von Bash, zsh, o.ä. interpretiert werden). Escaped aktuell drei Steuerzeichen:

```
` 
$
"
```

Beispiel für Commits mit Backticks: https://github.com/process-engine/process_engine_runtime/pull/467