### PR TITLE
🐛 Fix bug where npm-install-only does not work correctly

### DIFF
--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -45,11 +45,11 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`);
 
-  if (foundPatternMatchingPackagesWithNoStrictVersion.length !== 0) {
+  if (npmInstallArguments.length !== 0) {
     await annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
   }
 
-  if (foundPatternMatchingPackagesWithStrictVersion.length !== 0) {
+  if (npmInstallSaveExactArguments.length !== 0) {
     await annotatedSh(`npm install --save-exact ${npmInstallSaveExactArguments}`, isDryRun);
   }
 

--- a/src/commands/npm-install-only.ts
+++ b/src/commands/npm-install-only.ts
@@ -45,8 +45,13 @@ export async function run(...args): Promise<boolean> {
 
   console.log(`${BADGE}`);
 
-  await annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
-  await annotatedSh(`npm install --save-exact ${npmInstallSaveExactArguments}`, isDryRun);
+  if (foundPatternMatchingPackagesWithNoStrictVersion.length !== 0) {
+    await annotatedSh(`npm install ${npmInstallArguments}`, isDryRun);
+  }
+
+  if (foundPatternMatchingPackagesWithStrictVersion.length !== 0) {
+    await annotatedSh(`npm install --save-exact ${npmInstallSaveExactArguments}`, isDryRun);
+  }
 
   return true;
 }
@@ -91,32 +96,38 @@ function getPackageNamesMatchingPattern(allPackageNames: string[], patternList: 
 function getAllPackageNamesWithNoStrictVersion(): string[] {
   const content = readFileSync('package.json').toString();
   const json = JSON.parse(content);
+  let dependencies: string[] = [];
+  let devDependencies: string[] = [];
 
-  const dependencies: string[] = Object.keys(json.dependencies)
-    .filter((dependency): boolean => {
-      const version: string = json.dependencies[dependency];
+  if (json.dependencies) {
+    dependencies = Object.keys(json.dependencies)
+      .filter((dependency): boolean => {
+        const version: string = json.dependencies[dependency];
 
-      const versionIsNotStrict: boolean = version.startsWith('^') || version.startsWith('~');
+        const versionIsNotStrict: boolean = version.startsWith('^') || version.startsWith('~');
 
-      return versionIsNotStrict;
-    })
-    .map((dependency: string): string => {
-      const version: string = json.dependencies[dependency];
+        return versionIsNotStrict;
+      })
+      .map((dependency: string): string => {
+        const version: string = json.dependencies[dependency];
 
-      return `${dependency}@${version}`;
-    });
+        return `${dependency}@${version}`;
+      });
+  }
 
-  const devDependencies: string[] = Object.keys(json.devDependencies)
-    .filter((devDependency): boolean => {
-      const version: string = json.devDependencies[devDependency];
+  if (json.devDependencies) {
+    devDependencies = Object.keys(json.devDependencies)
+      .filter((devDependency): boolean => {
+        const version: string = json.devDependencies[devDependency];
 
-      const versionIsNotStrict: boolean = version.startsWith('^') || version.startsWith('~');
+        const versionIsNotStrict: boolean = version.startsWith('^') || version.startsWith('~');
 
-      return versionIsNotStrict;
-    })
-    .map((devDependency: string): string => {
-      return `${devDependency}@${json.devDependencies[devDependency]}`;
-    });
+        return versionIsNotStrict;
+      })
+      .map((devDependency: string): string => {
+        return `${devDependency}@${json.devDependencies[devDependency]}`;
+      });
+  }
 
   const allPackageNames: string[] = [...dependencies].concat(devDependencies).sort();
 
@@ -126,32 +137,38 @@ function getAllPackageNamesWithNoStrictVersion(): string[] {
 function getAllPackageNamesWithStrictVersion(): string[] {
   const content = readFileSync('package.json').toString();
   const json = JSON.parse(content);
+  let dependencies: string[] = [];
+  let devDependencies: string[] = [];
 
-  const dependencies: string[] = Object.keys(json.dependencies)
-    .filter((dependency): boolean => {
-      const version: string = json.dependencies[dependency];
+  if (json.dependencies) {
+    dependencies = Object.keys(json.dependencies)
+      .filter((dependency): boolean => {
+        const version: string = json.dependencies[dependency];
 
-      const versionIsStrict: boolean = !(version.startsWith('^') || version.startsWith('~'));
+        const versionIsStrict: boolean = !(version.startsWith('^') || version.startsWith('~'));
 
-      return versionIsStrict;
-    })
-    .map((dependency: string): string => {
-      const version: string = json.dependencies[dependency];
+        return versionIsStrict;
+      })
+      .map((dependency: string): string => {
+        const version: string = json.dependencies[dependency];
 
-      return `${dependency}@${version}`;
-    });
+        return `${dependency}@${version}`;
+      });
+  }
 
-  const devDependencies: string[] = Object.keys(json.devDependencies)
-    .filter((devDependency): boolean => {
-      const version: string = json.devDependencies[devDependency];
+  if (json.devDependencies) {
+    devDependencies = Object.keys(json.devDependencies)
+      .filter((devDependency): boolean => {
+        const version: string = json.devDependencies[devDependency];
 
-      const versionIsNotStrict: boolean = !(version.startsWith('^') || version.startsWith('~'));
+        const versionIsNotStrict: boolean = !(version.startsWith('^') || version.startsWith('~'));
 
-      return versionIsNotStrict;
-    })
-    .map((devDependency: string): string => {
-      return `${devDependency}@${json.devDependencies[devDependency]}`;
-    });
+        return versionIsNotStrict;
+      })
+      .map((devDependency: string): string => {
+        return `${devDependency}@${json.devDependencies[devDependency]}`;
+      });
+  }
 
   const allPackageNames: string[] = [...dependencies].concat(devDependencies).sort();
 


### PR DESCRIPTION
## Changes

1. Fix bug where `Object.keys` does not work on null or undefined

## Issues

PR: #37 

## How to test the changes

use `./node_modules/.bin/ci_tools npm-install-only --except-on-primary-branches @process-engine/ @essential-projects/` on a package which does not have any dependencies or devDependencies e.g. solutionexplorer.contracts
