### PR TITLE
✨ Add Release Announcement Support

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -13,6 +13,7 @@ import * as PublishNpmPackage from './commands/publish-npm-package';
 import * as SetupGitAndNpmConnections from './commands/internal/setup-git-and-npm-connections';
 import * as UpdateGithubRelease from './commands/update-github-release';
 import * as UpgradeDependenciesWithPreVersions from './commands/upgrade-dependencies-with-pre-versions';
+import * as PublishReleasenotesOnSlack from './commands/publish-releasenotes-on-slack';
 
 import { getGitBranch } from './git/git';
 import { PRIMARY_BRANCHES } from './versions/increment_version';
@@ -24,7 +25,8 @@ const COMMAND_HANDLERS = {
   'publish-npm-package': PublishNpmPackage,
   'npm-install-only': NpmInstallOnly,
   'update-github-release': UpdateGithubRelease,
-  'upgrade-dependencies-with-pre-versions': UpgradeDependenciesWithPreVersions
+  'upgrade-dependencies-with-pre-versions': UpgradeDependenciesWithPreVersions,
+  'publish-releasenotes-on-slack': PublishReleasenotesOnSlack
 };
 
 // Internal commands are only used to develop ci_tools and are not intended for public consumption.

--- a/src/commands/internal/create-changelog-announcement.ts
+++ b/src/commands/internal/create-changelog-announcement.ts
@@ -1,0 +1,138 @@
+import chalk from 'chalk';
+import fetch from 'node-fetch';
+import * as moment from 'moment';
+
+import { PullRequest, getMergedPullRequests } from '../../github/pull_requests';
+import { getCurrentApiBaseUrlWithAuth, getGitCommitListSince } from '../../git/git';
+import { getNextVersion, getPrevVersionTag, getVersionTag } from '../../versions/git_helpers';
+
+type CommitFromApi = any;
+
+const COMMIT_API_URI = getCurrentApiBaseUrlWithAuth('/commits/:commit_sha');
+
+const BADGE = '[create-changelog-announcement]\t';
+
+const MERGED_PULL_REQUEST_LENGTH_THRESHOLD = 100;
+
+// two weeks for feature-freeze period plus one week buffer for late releases
+const CONSIDER_PULL_REQUESTS_WEEKS_BACK = 3;
+
+/**
+ * Creates a changelog announcement based on data available in Git and GitHub:
+ *
+ * - Git: latest commits and tags
+ * - GitHub: PRs and Issues
+ */
+export async function run(...args): Promise<boolean> {
+  let startRef = args[0];
+  if (!startRef) {
+    startRef = getPrevVersionTag();
+    console.log(`${BADGE}No start ref given, using: "${startRef}"`);
+  }
+  const changelogAnnouncementText = await getChangelogAnnouncementText(startRef);
+
+  console.log(changelogAnnouncementText);
+  return true;
+}
+
+export async function getChangelogAnnouncementText(startRef: string): Promise<string> {
+  const startCommit = await getCommitFromApi(startRef);
+  const startCommitDate = startCommit.commit.committer.date;
+  const startDate = moment(startCommitDate)
+    .subtract(CONSIDER_PULL_REQUESTS_WEEKS_BACK, 'weeks')
+    .toISOString();
+
+  const endRef = 'HEAD';
+
+  const nextVersion = getNextVersion();
+  if (nextVersion == null) {
+    console.error(chalk.red(`${BADGE}Could not determine nextVersion!`));
+    process.exit(3);
+  }
+
+  const nextVersionTag = getVersionTag(nextVersion);
+
+  printInfo(startRef, startDate, endRef, nextVersion, nextVersionTag);
+
+  const mergedPullRequestsSince = await getMergedPullRequests(startDate);
+  const mergedPullRequests = filterPullRequestsForBranch(mergedPullRequestsSince, '', startRef, startDate);
+
+  if (mergedPullRequests.length >= MERGED_PULL_REQUEST_LENGTH_THRESHOLD) {
+    console.error(chalk.red(`${BADGE}Sanity check failed!`));
+    console.error(chalk.red(`${BADGE}Found an unexpectedly high number of merged pull requests:`));
+    console.error(
+      chalk.red(`${BADGE}  ${mergedPullRequests.length} (threshold is ${MERGED_PULL_REQUEST_LENGTH_THRESHOLD})`)
+    );
+    process.exit(2);
+  }
+
+  const mergedPullRequestsText = mergedPullRequests
+    .map((pr: PullRequest): string => {
+      const title = ensureSpaceAfterLeadingEmoji(pr.title);
+
+      return `- ${title}`;
+    })
+    .join('\n');
+
+  const changelogText = `
+*BPMN Studio ${nextVersionTag} was released*
+
+The new version includes the following changes:
+
+${mergedPullRequestsText}
+  `.trim();
+
+  return changelogText;
+}
+
+async function getCommitFromApi(ref: string): Promise<CommitFromApi> {
+  const url = COMMIT_API_URI.replace(':commit_sha', ref);
+  const response = await fetch(url);
+
+  return response.json();
+}
+
+function printInfo(
+  startRef: string,
+  startDate: string,
+  endRef: string,
+  nextVersion: string,
+  nextVersionTag: string
+): void {
+  console.log(`${BADGE}startRef:`, startRef);
+  console.log(`${BADGE}startDate:`, startDate);
+  console.log(`${BADGE}endRef:`, endRef);
+  console.log(`${BADGE}nextVersion:`, nextVersion);
+  console.log(`${BADGE}nextVersionTag:`, nextVersionTag);
+  console.log('');
+}
+
+function ensureSpaceAfterLeadingEmoji(text: string): string {
+  const emojiWithoutTrailingSpaceRegex = /([\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])(\S)/gu;
+
+  return text.replace(
+    emojiWithoutTrailingSpaceRegex,
+    (substring: string, emojiMatch: string, characterAfterEmojiMatch: string): string => {
+      return `${emojiMatch} ${characterAfterEmojiMatch}`;
+    }
+  );
+}
+
+function filterPullRequestsForBranch(
+  prs: PullRequest[],
+  branchName: string,
+  startRef: string,
+  since: string
+): PullRequest[] {
+  const allShaInCurrentBranch = getGitCommitListSince(branchName, since).split('\n');
+  const allShaInStartRef = getGitCommitListSince(startRef, since).split('\n');
+  const newShaInCurrentBranch = allShaInCurrentBranch.filter(
+    (currentSha: string): boolean => allShaInStartRef.indexOf(currentSha) === -1
+  );
+  const filteredPrs = prs.filter(
+    (pr: PullRequest): boolean =>
+      newShaInCurrentBranch.indexOf(pr.headSha) !== -1 || newShaInCurrentBranch.indexOf(pr.mergeCommitSha) !== -1
+  );
+
+  return filteredPrs;
+}

--- a/src/commands/internal/create-release-announcement.ts
+++ b/src/commands/internal/create-release-announcement.ts
@@ -24,18 +24,6 @@ const CONSIDER_PULL_REQUESTS_WEEKS_BACK = 3;
  * - Git: latest commits and tags
  * - GitHub: PRs
  */
-export async function run(...args): Promise<boolean> {
-  let startRef = args[0];
-  if (!startRef) {
-    startRef = getPrevVersionTag();
-    console.log(`${BADGE}No start ref given, using: "${startRef}"`);
-  }
-  const changelogAnnouncementText = await getReleaseAnnouncement();
-
-  console.log(changelogAnnouncementText);
-  return true;
-}
-
 export async function getReleaseAnnouncement(): Promise<string> {
   const startRef: string = getPrevVersionTag();
   const startCommit = await getCommitFromApi(startRef);

--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -1,0 +1,59 @@
+import { getGitBranch } from '../git/git';
+import { getPackageVersion, getPackageVersionTag } from '../versions/package_version';
+import { getPrevVersionTag } from '../versions/git_helpers';
+import { setupGit } from './internal/setup-git-and-npm-connections';
+import { sh } from '../cli/shell';
+import { printMultiLineString } from '../cli/printMultiLineString';
+import { sendSlackMessage } from '../slack/notifier';
+import { getChangelogAnnouncementText } from './internal/create-changelog-announcement';
+
+const COMMAND_NAME = 'publish-releasenotes-on-slack';
+const BADGE = `[${COMMAND_NAME}]\t`;
+
+const DOC = `
+Publishes the releasenotes for the current version on slack.
+`;
+// DOC: see above
+export async function run(...args): Promise<boolean> {
+  setupGit();
+
+  printInfo();
+
+  annotatedSh('git config user.name');
+  annotatedSh('git config user.email');
+
+  const releasenotes = await getChangelogAnnouncementText(getPrevVersionTag());
+
+  await sendSlackMessage(releasenotes);
+
+  return true;
+}
+
+export function getShortDoc(): string {
+  return DOC.trim().split('\n')[0];
+}
+
+export function printHelp(): void {
+  console.log(`Usage: ci_tools ${COMMAND_NAME}`);
+  console.log('');
+  console.log(DOC.trim());
+}
+
+function annotatedSh(cmd: string): string {
+  console.log(`${BADGE}|>>> ${cmd}`);
+  const output = sh(cmd);
+  printMultiLineString(output, `${BADGE}| `);
+
+  return output;
+}
+
+function printInfo(): void {
+  const packageVersion = getPackageVersion();
+  const packageVersionTag = getPackageVersionTag();
+  const branchName = getGitBranch();
+
+  console.log(`${BADGE}packageVersion:`, packageVersion);
+  console.log(`${BADGE}packageVersionTag:`, packageVersionTag);
+  console.log(`${BADGE}branchName:`, branchName);
+  console.log('');
+}

--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -11,6 +11,8 @@ const BADGE = `[${COMMAND_NAME}]\t`;
 
 const DOC = `
 Publishes the releasenotes for the current version on slack.
+
+To use this command, an incoming webhook for slack is required and must be configured as an environment variable named 'SLACK_WEBHOOK'.
 `;
 // DOC: see above
 export async function run(): Promise<boolean> {

--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -1,11 +1,10 @@
 import { getGitBranch } from '../git/git';
 import { getPackageVersion, getPackageVersionTag } from '../versions/package_version';
-import { getPrevVersionTag } from '../versions/git_helpers';
 import { setupGit } from './internal/setup-git-and-npm-connections';
 import { sh } from '../cli/shell';
 import { printMultiLineString } from '../cli/printMultiLineString';
 import { sendSlackMessage } from '../slack/notifier';
-import { getChangelogAnnouncementText } from './internal/create-changelog-announcement';
+import { getReleaseAnnouncement } from './internal/create-release-announcement';
 
 const COMMAND_NAME = 'publish-releasenotes-on-slack';
 const BADGE = `[${COMMAND_NAME}]\t`;
@@ -22,7 +21,7 @@ export async function run(...args): Promise<boolean> {
   annotatedSh('git config user.name');
   annotatedSh('git config user.email');
 
-  const releasenotes = await getChangelogAnnouncementText(getPrevVersionTag());
+  const releasenotes = await getReleaseAnnouncement();
 
   await sendSlackMessage(releasenotes);
 

--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -13,7 +13,7 @@ const DOC = `
 Publishes the releasenotes for the current version on slack.
 `;
 // DOC: see above
-export async function run(...args): Promise<boolean> {
+export async function run(): Promise<boolean> {
   setupGit();
 
   printInfo();

--- a/src/slack/notifier.ts
+++ b/src/slack/notifier.ts
@@ -16,7 +16,7 @@ function getSlackWebhook(): string {
   const webhook: string = process.env.SLACK_WEBHOOK;
 
   if (webhook === undefined) {
-    throw new Error("The slack webhook must be provided via environment variable 'SLACK_WEBHOOK'");
+    throw new Error("The slack incoming webhook URL must be configured as environment variable 'SLACK_WEBHOOK'!");
   }
 
   return webhook;

--- a/src/slack/notifier.ts
+++ b/src/slack/notifier.ts
@@ -1,0 +1,23 @@
+import fetch, { Response } from 'node-fetch';
+
+export function sendSlackMessage(message: string): Promise<Response> {
+  const body = {
+    text: message
+  };
+
+  return fetch(getSlackWebhook(), {
+    method: 'post',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+function getSlackWebhook(): string {
+  const webhook: string = process.env.SLACK_WEBHOOK;
+
+  if (webhook === undefined) {
+    throw new Error("The slack webhook must be provided via environment variable 'SLACK_WEBHOOK'");
+  }
+
+  return webhook;
+}


### PR DESCRIPTION
## Changes

1. Add Changelog Announcement Creation
2. Add Slack Support
3. Add 'publish-releasenotes-on-slack' Command

PR: #38

## How to test the changes

> Create an incoming webhook via https://slack.com/apps/A0F7XDUAZ-incoming-webhooks

- Link this PR into BPMN Studio
- Run `SLACK_WEBHOOK=<incoming webhook url> ci_tools publish-releasenotes-on-slack`


<img width="807" alt="Bildschirmfoto 2019-12-03 um 14 41 00" src="https://user-images.githubusercontent.com/20394992/70056525-e4de0c80-15db-11ea-9c1e-25aa689cd21e.png">
