### PR TITLE
✨Add --allow-empty argument to git commit command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/ci_tools",
-  "version": "2.4.0-alpha.3",
+  "version": "2.5.0-alpha.1",
   "description": "CI tools for process-engine.io",
   "main": "dist/ci_tools.js",
   "scripts": {

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -84,7 +84,7 @@ export function gitAdd(...files: string[]): GitOperationResult {
 export function gitCommit(commitMessage: string): GitOperationResult {
   const escapedCommitMessage = escapeForShell(commitMessage);
 
-  return sh(`git commit -m "${escapedCommitMessage}"`);
+  return sh(`git commit --allow-empty -m "${escapedCommitMessage}"`);
 }
 
 export function gitTag(newTag: string): GitOperationResult {


### PR DESCRIPTION
## Changes

1. Add --allow-empty argument to the git commit command

## Issues

PR: #41 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
