### PR TITLE
Separate dotnet and node functions into modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",
-    "lint": "eslint src/**/*.ts src/*.ts",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "mocha -r ts-node/register src/**/*.test.ts"
   },
   "bin": {

--- a/src/commands/get-version.ts
+++ b/src/commands/get-version.ts
@@ -6,6 +6,11 @@ const DEFAULT_MODE = 'node';
 
 const DOC = `
 Returns the package version.
+
+OPTIONS
+
+--mode    sets the package mode [dotnet, node] (default: node)
+
 `;
 
 export async function run(...args): Promise<boolean> {
@@ -31,7 +36,7 @@ export function getShortDoc(): string {
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ci_tools ${COMMAND_NAME} [--major]`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} [--major] [--mode <MODE>]`);
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/commands/prepare-version.ts
+++ b/src/commands/prepare-version.ts
@@ -17,9 +17,16 @@ const BADGE = `[${COMMAND_NAME}]\t`;
 const DEFAULT_MODE = 'node';
 
 const DOC = `
-Adjusts the pre-version in \`package.json\` automatically.
+Adjusts the pre-version in your project file automatically (\`package.json\` for Node or \`*.csproj\` for C# .NET).
 
-Example:
+OPTIONS
+
+--allow-dirty-workdir   allows for a "dirty" Git workdir
+--dry                   performs a dry which does not changes any files
+--force                 overrides all plausibility checks and increments the pre-version
+--mode                  sets the package mode [dotnet, node] (default: node)
+
+EXAMPLES
 
 Your package.json's version field is
 
@@ -87,7 +94,7 @@ export function getShortDoc(): string {
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ci_tools ${COMMAND_NAME} [--dry] [--force]`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} [--allow-dirty-workdir] [--dry] [--force] [--mode <MODE>]`);
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/commands/set-version.ts
+++ b/src/commands/set-version.ts
@@ -6,6 +6,11 @@ const DEFAULT_MODE = 'node';
 
 const DOC = `
 Sets the package version.
+
+OPTIONS
+
+--mode      sets the package mode [dotnet, node] (default: node)
+--version   the version to be set
 `;
 
 export async function run(...args): Promise<boolean> {
@@ -28,7 +33,7 @@ export function getShortDoc(): string {
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ci_tools ${COMMAND_NAME} [--version="<version>"]`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} [--version <VERSION>] [--mode <MODE>]`);
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/commands/upgrade-dependencies-with-pre-versions.test.ts
+++ b/src/commands/upgrade-dependencies-with-pre-versions.test.ts
@@ -14,21 +14,21 @@ const VERSION_LIST = [
   '2.1.0-beta.1'
 ];
 
-describe('upgrade-dependencies-with-pre-versions.ts', (): void => {
-  describe('getVersionToUpgradeTo()', (): void => {
-    it('should work as expected for beta requirements', (): void => {
+describe('upgrade-dependencies-with-pre-versions.ts', () => {
+  describe('getVersionToUpgradeTo()', () => {
+    it('should work as expected for beta requirements', () => {
       assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-beta.1', VERSION_LIST), null);
       assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0-beta.1', VERSION_LIST), '2.0.0');
       assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0-beta.2', VERSION_LIST), '2.0.0');
     });
 
-    it('should work as expected for stable requirements', (): void => {
+    it('should work as expected for stable requirements', () => {
       assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1', VERSION_LIST), null);
       assert.deepStrictEqual(getVersionToUpgradeTo('2.0.0', VERSION_LIST), null);
       assert.deepStrictEqual(getVersionToUpgradeTo('2.1.0', VERSION_LIST), null);
     });
 
-    it('should work as expected for alpha requirements', (): void => {
+    it('should work as expected for alpha requirements', () => {
       assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-alpha.9', VERSION_LIST), null);
       assert.deepStrictEqual(getVersionToUpgradeTo('1.2.1-alpha.8', VERSION_LIST), '1.2.1-alpha.9');
     });

--- a/src/npm/tag.test.ts
+++ b/src/npm/tag.test.ts
@@ -1,15 +1,15 @@
 import * as assert from 'assert';
 import { getNpmTag } from './tag';
 
-describe('tag.ts', (): void => {
-  describe('getNpmTag()', (): void => {
-    it('should return the right tags for primary branches', (): void => {
+describe('tag.ts', () => {
+  describe('getNpmTag()', () => {
+    it('should return the right tags for primary branches', () => {
       assert.strictEqual(getNpmTag('master'), null);
       assert.strictEqual(getNpmTag('beta'), 'beta');
       assert.strictEqual(getNpmTag('develop'), 'alpha');
     });
 
-    it('should return the right tags for secondary branches', (): void => {
+    it('should return the right tags for secondary branches', () => {
       assert.strictEqual(getNpmTag('feature/add-new-feature'), 'feature~add-new-feature');
       assert.strictEqual(getNpmTag('refs/pull/16/merge'), 'refs~pull~16~merge');
     });

--- a/src/versions/increment_version.test.ts
+++ b/src/versions/increment_version.test.ts
@@ -14,35 +14,35 @@ v2.0.0-alpha.2
 v2.0.0-alpha.3
 v2.1.0-beta.1`;
 
-describe('increment_version.ts', (): void => {
-  describe('incrementVersion()', (): void => {
-    it('should return the incremented version for the first alpha build of a new version', (): void => {
+describe('increment_version.ts', () => {
+  describe('incrementVersion()', () => {
+    it('should return the incremented version for the first alpha build of a new version', () => {
       assert.equal(incrementVersion('3.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha.1');
     });
-    it('should return the incremented version for unknown pre-version suffixes', (): void => {
+    it('should return the incremented version for unknown pre-version suffixes', () => {
       assert.equal(incrementVersion('3.2.1-asdf5', BRANCH_DEVELOP, GIT_TAG_LIST), '3.2.1-alpha.1');
     });
-    it('should return the incremented version for subsequent alpha versions', (): void => {
+    it('should return the incremented version for subsequent alpha versions', () => {
       assert.equal(incrementVersion('1.2.1-alpha.7', BRANCH_DEVELOP, GIT_TAG_LIST), '1.2.1-alpha.11');
     });
 
-    it('should return the incremented version for the first beta build of a alpha version', (): void => {
+    it('should return the incremented version for the first beta build of a alpha version', () => {
       assert.equal(incrementVersion('3.2.1-alpha.3', BRANCH_BETA, GIT_TAG_LIST), '3.2.1-beta.1');
     });
-    it('should return the incremented version for subsequent beta versions', (): void => {
+    it('should return the incremented version for subsequent beta versions', () => {
       // v2.1.0-beta.3 not in tag list, falling back to numbering found there
       assert.equal(incrementVersion('2.1.0-beta.3', BRANCH_BETA, GIT_TAG_LIST), '2.1.0-beta.2');
     });
-    it('should return the incremented version for the stable build of a alpha version', (): void => {
+    it('should return the incremented version for the stable build of a alpha version', () => {
       assert.equal(incrementVersion('3.2.1-alpha.42', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
     });
-    it('should return the incremented version for the stable build of a beta version', (): void => {
+    it('should return the incremented version for the stable build of a beta version', () => {
       assert.equal(incrementVersion('3.2.1-beta.4', BRANCH_MASTER, GIT_TAG_LIST), '3.2.1');
     });
   });
 
-  describe('findNextSuffixNumber()', (): void => {
-    it('should work', (): void => {
+  describe('findNextSuffixNumber()', () => {
+    it('should work', () => {
       assert.equal(findNextSuffixNumber('1.2.1', BRANCH_DEVELOP, GIT_TAG_LIST), 11);
       assert.equal(findNextSuffixNumber('1.3.0', BRANCH_DEVELOP, GIT_TAG_LIST), 1);
       assert.equal(findNextSuffixNumber('2.0.0', BRANCH_DEVELOP, GIT_TAG_LIST), 4);

--- a/src/versions/package_version.test.ts
+++ b/src/versions/package_version.test.ts
@@ -3,16 +3,16 @@ import { getMajorPackageVersion, getPackageVersion, getPackageVersionTag } from 
 
 import { inDir } from '../../test/test_functions';
 
-describe('package_version.ts', (): void => {
-  describe('getPackageVersion()', (): void => {
-    it('should return the version for node', (): void => {
+describe('package_version.ts', () => {
+  describe('getPackageVersion()', () => {
+    it('should return the version for node', () => {
       inDir('test/fixtures/node-simple', () => {
         const packageVersion = getPackageVersion('node');
         assert.equal(packageVersion, '1.2.3');
       });
     });
 
-    it('should return the version for dotnet', (): void => {
+    it('should return the version for dotnet', () => {
       inDir('test/fixtures/dotnet-simple', () => {
         const packageVersion = getPackageVersion('dotnet');
         assert.equal(packageVersion, '3.2.1');
@@ -20,15 +20,15 @@ describe('package_version.ts', (): void => {
     });
   });
 
-  describe('getMajorPackageVersion()', (): void => {
-    it('should return the version for node', (): void => {
+  describe('getMajorPackageVersion()', () => {
+    it('should return the version for node', () => {
       inDir('test/fixtures/node-simple', () => {
         const packageVersion = getMajorPackageVersion('node');
         assert.equal(packageVersion, '1');
       });
     });
 
-    it('should return the version for dotnet', (): void => {
+    it('should return the version for dotnet', () => {
       inDir('test/fixtures/dotnet-simple', () => {
         const packageVersion = getMajorPackageVersion('dotnet');
         assert.equal(packageVersion, '3');
@@ -36,15 +36,15 @@ describe('package_version.ts', (): void => {
     });
   });
 
-  describe('getPackageVersionTag()', (): void => {
-    it('should return the version for node', (): void => {
+  describe('getPackageVersionTag()', () => {
+    it('should return the version for node', () => {
       inDir('test/fixtures/node-simple', () => {
         const packageVersionTag = getPackageVersionTag('node');
         assert.equal(packageVersionTag, 'v1.2.3');
       });
     });
 
-    it('should return the version for dotnet', (): void => {
+    it('should return the version for dotnet', () => {
       inDir('test/fixtures/dotnet-simple', () => {
         const packageVersionTag = getPackageVersionTag('dotnet');
         assert.equal(packageVersionTag, 'v3.2.1');

--- a/src/versions/package_version.ts
+++ b/src/versions/package_version.ts
@@ -25,12 +25,13 @@ export function getPackageVersionTag(mode): string {
 }
 
 export function setPackageVersion(mode: string, version: string): void {
-  if (mode === PACKAGE_MODE_DOTNET) {
-    setPackageVersionDotnet(version);
-  } else if (mode === PACKAGE_MODE_NODE) {
-    setPackageVersionNode(version);
-  } else {
-    throw new Error(`Unknown value for \`mode\`: ${mode}`);
+  switch (mode) {
+    case PACKAGE_MODE_DOTNET:
+      setPackageVersionDotnet(version);
+    case PACKAGE_MODE_NODE:
+      setPackageVersionNode(version);
+    default:
+      throw new Error(`Unknown value for \`mode\`: ${mode}`);
   }
 }
 

--- a/src/versions/package_version.ts
+++ b/src/versions/package_version.ts
@@ -28,8 +28,10 @@ export function setPackageVersion(mode: string, version: string): void {
   switch (mode) {
     case PACKAGE_MODE_DOTNET:
       setPackageVersionDotnet(version);
+      return;
     case PACKAGE_MODE_NODE:
       setPackageVersionNode(version);
+      return;
     default:
       throw new Error(`Unknown value for \`mode\`: ${mode}`);
   }

--- a/src/versions/package_version/dotnet.ts
+++ b/src/versions/package_version/dotnet.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as parser from 'xml2json';
+import * as path from 'path';
+import { sh } from '../../cli/shell';
+
+export function getPackageVersionDotnet(): string {
+  const pathToCsproj = getCsprojPath();
+  const version = JSON.parse(getJsonFromFile(pathToCsproj)).Project.PropertyGroup.Version;
+
+  return version;
+}
+
+export function setPackageVersionDotnet(newVersion: string): void {
+  const currentVersion = getPackageVersionDotnet();
+  if (currentVersion == null) {
+    throw new Error('Unexpected value: `currentVersion` should not be null here.');
+  }
+
+  const pathToCsproj = getCsprojPath();
+  const csProj = fs.readFileSync(pathToCsproj, { encoding: 'utf8' });
+  const csProjWithNewVersion = csProj.replace(
+    `<Version>${currentVersion}</Version>`,
+    `<Version>${newVersion}</Version>`
+  );
+
+  fs.writeFileSync(pathToCsproj, csProjWithNewVersion);
+}
+
+function getJsonFromFile(filePath: string): string {
+  const csproj = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+  const jsonString = parser.toJson(csproj);
+
+  return jsonString;
+}
+
+function getCsprojPath(): string {
+  if (process.platform === 'win32') {
+    return getCsprojPathOnWindows();
+  }
+
+  return getCsprojPathOnNonWindows();
+}
+
+function getCsprojPathOnWindows(): string {
+  const result = sh('where /r . *.csproj');
+  const paths = result.split('\n');
+
+  const relativeCsprojPath = findRelativeCsprojPath(paths);
+  return relativeCsprojPath.replace(/\r/g, '');
+}
+
+function getCsprojPathOnNonWindows(): string {
+  const result = sh('find . -print | grep -i .csproj');
+  const paths = result.split('\n');
+
+  return findRelativeCsprojPath(paths);
+}
+
+function findRelativeCsprojPath(paths: Array<string>): string {
+  const filteredPaths = paths.filter((filePath: string) => {
+    // Replace the current working dir, because Windows returns absolute paths when using `where`
+    const relativePathToCsproj = filePath.trim().replace(process.cwd(), '');
+    const parsedPath = path.parse(relativePathToCsproj);
+
+    return (
+      relativePathToCsproj.endsWith('.csproj') && !parsedPath.dir.includes('test') && !parsedPath.dir.includes('tests')
+    );
+  });
+
+  if (filteredPaths.length > 1) {
+    throw new Error(`More than one .csproj file found: ${filteredPaths}`);
+  }
+
+  return filteredPaths[0];
+}

--- a/src/versions/package_version/dotnet.ts
+++ b/src/versions/package_version/dotnet.ts
@@ -3,6 +3,9 @@ import * as parser from 'xml2json';
 import * as path from 'path';
 import { sh } from '../../cli/shell';
 
+/**
+ * Internal: Used by package_version.ts
+ */
 export function getPackageVersionDotnet(): string {
   const pathToCsproj = getCsprojPath();
   const version = JSON.parse(getJsonFromFile(pathToCsproj)).Project.PropertyGroup.Version;
@@ -10,6 +13,9 @@ export function getPackageVersionDotnet(): string {
   return version;
 }
 
+/**
+ * Internal: Used by package_version.ts
+ */
 export function setPackageVersionDotnet(newVersion: string): void {
   const currentVersion = getPackageVersionDotnet();
   if (currentVersion == null) {

--- a/src/versions/package_version/node.ts
+++ b/src/versions/package_version/node.ts
@@ -1,0 +1,12 @@
+import { sh } from '../../cli/shell';
+
+export function getPackageVersionNode(): string {
+  const rawdata = fs.readFileSync('package.json').toString();
+  const packageJson = JSON.parse(rawdata);
+
+  return packageJson.version;
+}
+
+export function setPackageVersionNode(version: string): void {
+  sh(`npm version ${version} --no-git-tag-version`);
+}

--- a/src/versions/package_version/node.ts
+++ b/src/versions/package_version/node.ts
@@ -1,5 +1,9 @@
+import * as fs from 'fs';
 import { sh } from '../../cli/shell';
 
+/**
+ * Internal: Used by package_version.ts
+ */
 export function getPackageVersionNode(): string {
   const rawdata = fs.readFileSync('package.json').toString();
   const packageJson = JSON.parse(rawdata);
@@ -7,6 +11,9 @@ export function getPackageVersionNode(): string {
   return packageJson.version;
 }
 
+/**
+ * Internal: Used by package_version.ts
+ */
 export function setPackageVersionNode(version: string): void {
   sh(`npm version ${version} --no-git-tag-version`);
 }

--- a/src/versions/parse_version.test.ts
+++ b/src/versions/parse_version.test.ts
@@ -1,13 +1,13 @@
 import * as assert from 'assert';
 import { parseVersion } from './parse_version';
 
-describe('parse_version.ts', (): void => {
-  describe('parseVersion()', (): void => {
-    it('should return null for dist-tags', (): void => {
+describe('parse_version.ts', () => {
+  describe('parseVersion()', () => {
+    it('should return null for dist-tags', () => {
       assert.deepStrictEqual(parseVersion('alpha'), null);
     });
 
-    it('should work as expected for stable versions', (): void => {
+    it('should work as expected for stable versions', () => {
       const input = '2.2.0';
       const expected = {
         baseString: '2.2.0',
@@ -16,7 +16,7 @@ describe('parse_version.ts', (): void => {
       assert.deepStrictEqual(parseVersion(input), expected);
     });
 
-    it('should work as expected for alpha versions', (): void => {
+    it('should work as expected for alpha versions', () => {
       const input = '2.2.0-alpha.5';
       const expected = {
         baseString: '2.2.0',
@@ -26,7 +26,7 @@ describe('parse_version.ts', (): void => {
       assert.deepStrictEqual(parseVersion(input), expected);
     });
 
-    it('should work as expected for beta versions', (): void => {
+    it('should work as expected for beta versions', () => {
       const input = '0.2.0-beta.8';
       const expected = {
         baseString: '0.2.0',
@@ -36,7 +36,7 @@ describe('parse_version.ts', (): void => {
       assert.deepStrictEqual(parseVersion(input), expected);
     });
 
-    it('should return null as releaseChannel for unknown pre-version suffixes', (): void => {
+    it('should return null as releaseChannel for unknown pre-version suffixes', () => {
       const input = '3.2.1-asdf5';
       const expected = null;
       assert.deepStrictEqual(parseVersion(input), expected);

--- a/src/versions/previous_stable_version.test.ts
+++ b/src/versions/previous_stable_version.test.ts
@@ -13,31 +13,31 @@ v2.0.1
 v2.1.0-beta.1
 v3.2.0`;
 
-describe('previous_stable_version.ts', (): void => {
-  describe('previousVersion()', (): void => {
-    it('should return the previous version for the initial stable build', (): void => {
+describe('previous_stable_version.ts', () => {
+  describe('previousVersion()', () => {
+    it('should return the previous version for the initial stable build', () => {
       assert.equal(previousStableVersion('0.1.0', GIT_TAG_LIST), null);
     });
-    it('should return the previous version for a stable build', (): void => {
+    it('should return the previous version for a stable build', () => {
       assert.equal(previousStableVersion('2.0.0', GIT_TAG_LIST), '1.2.0');
     });
-    it('should return the previous version for the first alpha build of a new version', (): void => {
+    it('should return the previous version for the first alpha build of a new version', () => {
       assert.equal(previousStableVersion('3.2.1', GIT_TAG_LIST), '3.2.0');
     });
-    it('should return the previous version for unknown pre-version suffixes', (): void => {
+    it('should return the previous version for unknown pre-version suffixes', () => {
       assert.equal(previousStableVersion('3.2.1-asdf5', GIT_TAG_LIST), '3.2.0');
     });
-    it('should return the previous version for subsequent alpha versions', (): void => {
+    it('should return the previous version for subsequent alpha versions', () => {
       assert.equal(previousStableVersion('1.2.1-alpha.7', GIT_TAG_LIST), '1.2.0');
     });
 
-    it('should return the previous version for subsequent beta versions', (): void => {
+    it('should return the previous version for subsequent beta versions', () => {
       assert.equal(previousStableVersion('2.1.0-beta.3', GIT_TAG_LIST), '2.0.1');
     });
-    it('should return the previous version for the stable build of a alpha version', (): void => {
+    it('should return the previous version for the stable build of a alpha version', () => {
       assert.equal(previousStableVersion('3.3.0-alpha.42', GIT_TAG_LIST), '3.2.0');
     });
-    it('should return the previous version for the stable build of a beta version', (): void => {
+    it('should return the previous version for the stable build of a beta version', () => {
       assert.equal(previousStableVersion('2.0.0-alpha.4', GIT_TAG_LIST), '1.2.0');
     });
   });


### PR DESCRIPTION
Packt alle `dotnet`-spezifischen Funktionen in eine Datei und alle `node`-speifizischen in eine andere.