### PR TITLE
🐛 Fix error handling for "updateExistingRelease"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ npm-debug.log*
 
 # build directories
 dist
+bin
+obj
 
 # auto-generated schemas and documentation
 doc

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -160,7 +160,7 @@ async function updateExistingRelease(
         success = success && uploadSuccess;
       } catch (e) {
         const data = JSON.parse(e.message);
-        const alreadyExists = data.errors.length === 1 && data.errors[0].code === 'already_exists';
+        const alreadyExists = data?.errors?.length === 1 && data?.errors[0]?.code === 'already_exists';
 
         if (alreadyExists) {
           console.log(`${BADGE}  INFO: Asset '${filename}' already exists.`);


### PR DESCRIPTION
## Changes

I recently encountered the following error:

![Bildschirmfoto 2020-03-12 um 09 48 21](https://user-images.githubusercontent.com/15343316/76503765-ba0b1c00-6446-11ea-9c16-1d20d71edeb7.png)

This happened because the "data" object from the parsed error message did not contain an "errors" property. Consequently, the error that actually occurred was swallowed up and replaced by this most unhelpful error shown above.

By use of null-coalescing, we are now able to handle such cases.

## Issues

PR: #58

## How to test the changes

Kinda hard to test. Just "hope" that one of your GitHub releases fails, I guess... 