### PR TITLE
Add integration tests for dotnet mode

### DIFF
--- a/src/contracts/modes.ts
+++ b/src/contracts/modes.ts
@@ -1,0 +1,2 @@
+export const PACKAGE_MODE_DOTNET = 'dotnet';
+export const PACKAGE_MODE_NODE = 'node';

--- a/src/versions/package_version.ts
+++ b/src/versions/package_version.ts
@@ -1,8 +1,7 @@
 import { getPackageVersionDotnet, setPackageVersionDotnet } from './package_version/dotnet';
 import { getPackageVersionNode, setPackageVersionNode } from './package_version/node';
+import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE } from '../contracts/modes';
 
-const PACKAGE_MODE_DOTNET = 'dotnet';
-const PACKAGE_MODE_NODE = 'node';
 const versionRegex = /^(\d+)\.(\d+).(\d+)/;
 
 export async function getPackageVersion(mode: string): Promise<string> {

--- a/src/versions/package_version/dotnet.ts
+++ b/src/versions/package_version/dotnet.ts
@@ -14,7 +14,7 @@ export async function getPackageVersionDotnet(): Promise<string> {
     throw new Error(`Could not convert csproj to JSON: ${filename}`);
   }
   const propertyGroup = json?.Project?.PropertyGroup;
-  const version = Array.isArray(propertyGroup) ? propertyGroup[0]?.Version : null;
+  const version = Array.isArray(propertyGroup) ? propertyGroup[0]?.Version[0] : null;
   if (version == null) {
     throw new Error(`Could not read version from converted JSON: ${filename}\n\n${JSON.stringify(json, null, 2)}`);
   }

--- a/test/assert_functions.ts
+++ b/test/assert_functions.ts
@@ -3,9 +3,14 @@ import * as assert from 'assert';
 import * as JSON5 from 'json5';
 
 import { shell } from './test_functions';
+import { readFileSync } from 'fs';
 
 export function assertNodePackageVersion(version: string): void {
   assert.strictEqual(getNodePackageVersion(), version);
+}
+
+export function assertDotnetPackageVersion(filename: string, version: string): void {
+  assert.strictEqual(getDotnetPackageVersion(filename), version);
 }
 
 export function assertTagCount(count: number): void {
@@ -45,6 +50,13 @@ export function assertNewTagCreated(tag: string, callback: () => void): void {
 function getNodePackageVersion(): string {
   const output = shell('npm version');
   return JSON5.parse(output)['@process-engine/ci_tools'];
+}
+
+function getDotnetPackageVersion(csprojFilename: string): string {
+  const contents = readFileSync(csprojFilename, { encoding: 'utf-8' });
+  const matches = contents.match(/(<Version>)([^<]+)</);
+
+  return matches == null ? null : matches[2];
 }
 
 function getGitTags(): string[] {

--- a/test/integration/smoke.dotnet.test.ts
+++ b/test/integration/smoke.dotnet.test.ts
@@ -1,0 +1,67 @@
+import { inDirSync, run, setupGitWorkingCopyForTest, shell } from '../test_functions';
+import { assertDotnetPackageVersion, assertNewTagCreated, assertNoNewTagsCreated } from '../assert_functions';
+import { readFileSync, writeFileSync } from 'fs';
+
+const CSPROJ_FILENAME = 'ProcessEngine.Client.csproj';
+
+function setDotnetPackageVersionAndCommit(filename: string, version: string): void {
+  const contents = readFileSync(filename, { encoding: 'utf-8' });
+  const newContents = contents.replace(/(<Version>)([^<]+)(<\/Version>)/i, `$1${version}$3`);
+  writeFileSync(filename, newContents);
+
+  assertDotnetPackageVersion(filename, version);
+  shell(`git add ${filename}`);
+  shell(`git commit --message "Bump version to ${version}"`);
+}
+
+describe('ci_tools', () => {
+  it('should work with mode: dotnet', async () => {
+    const gitTempWorkingCopy = setupGitWorkingCopyForTest();
+    inDirSync(gitTempWorkingCopy, () => {
+      shell('git config user.email "process-engine-ci@5minds.de"');
+      shell('git config user.name "Integration Testbot"');
+
+      // alpha
+
+      shell('git checkout develop');
+      setDotnetPackageVersionAndCommit(CSPROJ_FILENAME, '1.2.1-dev');
+
+      assertNoNewTagsCreated(() => {
+        run('prepare-version --mode dotnet');
+        assertDotnetPackageVersion(CSPROJ_FILENAME, '1.2.1-alpha.11');
+      });
+
+      assertNewTagCreated('v1.2.1-alpha.11', () => {
+        run('commit-and-tag-version --mode dotnet');
+      });
+
+      // beta
+
+      shell('git checkout beta');
+      setDotnetPackageVersionAndCommit(CSPROJ_FILENAME, '1.2.1-dev');
+
+      assertNoNewTagsCreated(() => {
+        run('prepare-version --mode dotnet');
+        assertDotnetPackageVersion(CSPROJ_FILENAME, '1.2.1-beta.1');
+      });
+
+      assertNewTagCreated('v1.2.1-beta.1', () => {
+        run('commit-and-tag-version --mode dotnet');
+      });
+
+      // stable
+
+      shell('git checkout master');
+      setDotnetPackageVersionAndCommit(CSPROJ_FILENAME, '1.2.1-dev');
+
+      assertNoNewTagsCreated(() => {
+        run('prepare-version --mode dotnet');
+        assertDotnetPackageVersion(CSPROJ_FILENAME, '1.2.1');
+      });
+
+      assertNewTagCreated('v1.2.1', () => {
+        run('commit-and-tag-version --mode dotnet');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Gleiches Spiel wie gestern, nur diesmal für .NET Projekte.

Fügt also Smoke-Tests für die `prepare-version`- und `commit-and-tag-version`-Kommandos im Modus `dotnet` (a.k.a. `package.json`) hinzu.

Zum Testen:

```shell
npm run test:integration
```
