### PR TITLE
✨ Add new command to replace dist-tags with real versions

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -18,6 +18,7 @@ import * as PublishReleasenotesOnSlack from './commands/publish-releasenotes-on-
 import * as GetVersion from './commands/get-version';
 import * as SetVersion from './commands/set-version';
 import * as IsNugetPackagePublished from './legacy/is-nuget-package-published';
+import * as ReplaceDistTagsWithRealVersions from './commands/replace-dist-tags-with-real-versions';
 
 import { getGitBranch } from './git/git';
 import { PRIMARY_BRANCHES } from './versions/increment_version';
@@ -34,7 +35,8 @@ const COMMAND_HANDLERS = {
   'publish-releasenotes-on-slack': PublishReleasenotesOnSlack,
   'get-version': GetVersion,
   'set-version': SetVersion,
-  'is-nuget-package-published': IsNugetPackagePublished
+  'is-nuget-package-published': IsNugetPackagePublished,
+  'replace-dist-tags-with-real-versions': ReplaceDistTagsWithRealVersions,
 };
 
 // Internal commands are only used to develop ci_tools and are not intended for public consumption.

--- a/src/commands/replace-dist-tags-with-real-versions.ts
+++ b/src/commands/replace-dist-tags-with-real-versions.ts
@@ -1,0 +1,277 @@
+import * as fs from 'fs-extra';
+import * as yargsParser from 'yargs-parser';
+
+import { printMultiLineString } from '../cli/printMultiLineString';
+import { sh } from '../cli/shell';
+import { gitAdd, gitCommit, isDirty } from '../git/git';
+import {
+  Dependency,
+  convertToDependencyArray,
+  getDependencyAsString,
+  getLatestRevision,
+  getRegistryInfo,
+} from '../npm/dependency';
+import { ParsedVersion, parseVersion } from '../versions/parse_version';
+
+type DependencyType = 'prod' | 'dev' | 'optional';
+
+const COMMAND_NAME = 'replace-dist-tags-with-real-versions';
+const BADGE = `[${COMMAND_NAME}]\t`;
+
+const DOC = `
+Replaces dist tags (see npm help dist-tag) for all dependencies matching the given pattern with the latest version found
+for the respective dist tag in the npm registry.
+
+OPTIONS
+
+-d, --dist-tags-to-replace  specifies which dist tags should be replaced
+--create-git-commit         creates a Git commit when any changes were performed
+--dry                       performs a dry which does not make any persistent changes
+
+EXAMPLES
+
+Your package.json file contains the following dependencies:
+
+    @atlas-engine/iam: feature~new_awesome_feature
+    @atlas-engine/timing: 2.3.0-alpha.3
+    bluebird: 3.7.2
+
+After running "ci_tools replace-dist-tags-with-real-versions @atlas-engine/ -d feature" the result will be:
+
+    @atlas-engine/iam: 1.1.0-alpha.1
+    @atlas-engine/timing: 2.3.0-alpha.3
+    bluebird: 3.7.2
+`;
+
+export async function run(...args): Promise<boolean> {
+  const argv = parseArguments(args);
+  const isDryRun = argv.dry === true;
+  const shouldCreateGitCommit = argv.createGitCommit === true;
+  const distTagsToReplace = argv.distTagsToReplace;
+  const packagePatterns = argv._;
+
+  if (!distTagsToReplace) {
+    throw new Error('No dist tags to replace were specified');
+  }
+
+  const packagePatternFilter = getPackagePatternFilter(packagePatterns);
+  const distTagFilter = getDistTagFilter(distTagsToReplace);
+
+  const packageContentRaw = await fs.readFile('package.json', 'utf-8');
+  const packageContent = JSON.parse(packageContentRaw);
+
+  const dependencies = convertToDependencyArray(packageContent.dependencies ?? {})
+    .filter(packagePatternFilter)
+    .filter(distTagFilter);
+
+  const devDependencies = convertToDependencyArray(packageContent.devDependencies ?? {})
+    .filter(packagePatternFilter)
+    .filter(distTagFilter);
+
+  const optionalDependencies = convertToDependencyArray(packageContent.optionalDependencies ?? {})
+    .filter(packagePatternFilter)
+    .filter(distTagFilter);
+
+  if (dependencies.length === 0 && devDependencies.length === 0 && optionalDependencies.length === 0) {
+    annotatedLog('No dependencies to update.');
+    return true;
+  }
+
+  replaceDistTagsWithRealVersions(dependencies, 'prod', isDryRun);
+  replaceDistTagsWithRealVersions(devDependencies, 'dev', isDryRun);
+  replaceDistTagsWithRealVersions(optionalDependencies, 'optional', isDryRun);
+
+  if (shouldCreateGitCommit && isDirty('package.json')) {
+    createGitCommit(isDryRun);
+  }
+
+  return true;
+}
+
+export function getShortDoc(): string {
+  return DOC.trim().split('\n')[0];
+}
+
+export function printHelp(): void {
+  console.log(`Usage: ci_tools ${COMMAND_NAME} <package-pattern> [<package-pattern>...] [OPTIONS]`);
+  console.log('');
+  console.log(DOC.trim());
+}
+
+function parseArguments(args): yargsParser.Arguments {
+  return yargsParser(args, {
+    alias: { help: ['h'], distTagsToReplace: ['d'] },
+    boolean: ['dry', 'create-git-commit'],
+    array: ['dist-tags-to-replace'],
+  });
+}
+
+function annotatedLog(message: string): void {
+  console.log(`${BADGE}${message}`);
+}
+
+function annotatedSh(cmd: string): string {
+  console.log(`${BADGE}|>>> ${cmd}`);
+  const output = sh(cmd);
+  printMultiLineString(output, `${BADGE}| `);
+
+  return output;
+}
+
+function getPackagePatternFilter(packagePatterns: string[]): (dependency: Dependency) => boolean {
+  return (dependency: Dependency) => {
+    for (const packagePattern of packagePatterns) {
+      if (dependency.name.startsWith(packagePattern)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+}
+
+function getDistTagFilter(distTags: string[]): (dependency: Dependency) => boolean {
+  return (dependency: Dependency) => {
+    for (const distTag of distTags) {
+      if (dependency.version === distTag) {
+        return true;
+      }
+
+      if (distTag === 'feature' && dependency.version.match(/^feature~/) != null) {
+        return true;
+      }
+
+      if (dependency.version.match(/^\d+\.\d+\.\d+-/) != null) {
+        const parsedVersion = parseVersion(dependency.version);
+
+        if (parsedVersion && parsedVersion.releaseChannelName === distTag) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+}
+
+function getNextReleaseChannel(releaseChannel: string): string {
+  switch (releaseChannel) {
+    case 'feature':
+      return 'alpha';
+    case 'alpha':
+      return 'beta';
+    case 'beta':
+      return 'latest';
+    default:
+      throw new Error(`Could not determine next release channel for '${releaseChannel}'`);
+  }
+}
+
+function resolveFeatureDistTag(dependency: Dependency): string {
+  const dependencyRegistryInfo = getRegistryInfo(dependency.name);
+  const distTags = dependencyRegistryInfo['dist-tags'];
+  const featureVersion = distTags[dependency.version];
+
+  if (!featureVersion) {
+    throw new Error(`Could not resolve feature dist tag '${dependency.version}' for dependency '${dependency.name}'`);
+  }
+
+  return featureVersion;
+}
+
+function parseFeatureVersion(version: string): ParsedVersion {
+  const parts = version.split('-');
+  const baseString = parts[0];
+
+  return {
+    baseString: baseString,
+    releaseChannelName: 'feature',
+  };
+}
+
+function replaceVersionWithNextReleaseChannelVersion(dependency: Dependency): Dependency {
+  if (dependency.version === 'latest') {
+    return dependency;
+  }
+
+  if (dependency.version === 'alpha' || dependency.version === 'beta') {
+    return {
+      name: dependency.name,
+      version: getNextReleaseChannel(dependency.version),
+    };
+  }
+
+  let parsedVersion: ParsedVersion;
+
+  if (dependency.version.match(/^feature~/) != null) {
+    const featureVersion = resolveFeatureDistTag(dependency);
+    parsedVersion = parseFeatureVersion(featureVersion);
+  } else {
+    parsedVersion = parseVersion(dependency.version);
+  }
+
+  if (!parsedVersion) {
+    annotatedLog(`${dependency.name}: Could not parse version '${dependency.version}'. Keeping current version.`);
+    return dependency;
+  }
+
+  const nextReleaseChannel = getNextReleaseChannel(parsedVersion.releaseChannelName);
+  const latestRevisionForNextReleaseChannel = getLatestRevision(dependency.name, parsedVersion.baseString, nextReleaseChannel);
+
+  if (!latestRevisionForNextReleaseChannel) {
+    annotatedLog(`${dependency.name}: Could not find version '${parsedVersion.baseString}' for release channel '${nextReleaseChannel}'. Keeping current version.`);
+    return dependency;
+  }
+
+  return {
+    name: dependency.name,
+    version: latestRevisionForNextReleaseChannel,
+  };
+}
+
+function replaceDistTagsWithRealVersions(dependencies: Dependency[], dependencyType: DependencyType, isDryRun = false): void {
+  if (dependencies.length === 0) {
+    return;
+  }
+
+  const dependenciesWithReplacedVersions = dependencies.map(replaceVersionWithNextReleaseChannelVersion);
+
+  const concattedDependencies = dependenciesWithReplacedVersions
+    .map(getDependencyAsString)
+    .join(' ');
+
+  let command: string;
+
+  switch (dependencyType) {
+    case 'prod':
+      command = `npm install --save-exact ${concattedDependencies}`;
+      break;
+    case 'dev':
+      command = `npm install --save-exact --save-dev ${concattedDependencies}`;
+      break;
+    case 'optional':
+      command = `npm install --save-exact --save-optional ${concattedDependencies}`;
+      break;
+    default:
+      throw new Error(`Unknown dependency type '${dependencyType}' encountered`);
+  }
+
+  if (isDryRun) {
+    console.log(`${BADGE}|>>> ${command}`);
+  } else {
+    const npmOutput = annotatedSh(command);
+
+    if (npmOutput.includes('npm ERR!')) {
+      throw new Error('npm error occurred');
+    }
+  }
+}
+
+function createGitCommit(isDryRun = false): void {
+  annotatedLog('Creating Git commit');
+
+  if (!isDryRun) {
+    gitAdd('package.json', 'package-lock.json');
+    gitCommit('Harmonize dependency versions');
+  }
+}

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -109,8 +109,8 @@ export function gitPushTags(): GitOperationResult {
   return output;
 }
 
-export function isDirty(): boolean {
-  return sh('git status --porcelain --untracked-files=no').trim() !== '';
+export function isDirty(...pathspec: string[]): boolean {
+  return sh(`git status --porcelain --untracked-files=no ${pathspec.join(' ')}`).trim() !== '';
 }
 
 export function isExistingTag(name: string): boolean {

--- a/src/npm/dependency.test.ts
+++ b/src/npm/dependency.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+
+import {
+  Dependency,
+  convertToDependencyArray,
+  getDependencyAsString,
+} from './dependency';
+
+describe('dependency.ts', () => {
+  describe('convertToDependencyArray()', () => {
+    it('should return the passed dependency object as an array', () => {
+      const dependencyObject = {
+        foo: '1.2.3-beta.1',
+        bar: 'alpha',
+      };
+      const expectedDependencyArray: Dependency[] = [
+        { name: 'foo', version: '1.2.3-beta.1' },
+        { name: 'bar', version: 'alpha' },
+      ];
+
+      const actualDependencyArray = convertToDependencyArray(dependencyObject);
+
+      assert.deepStrictEqual(actualDependencyArray, expectedDependencyArray);
+    });
+  });
+
+  describe('getDependencyAsString()', () => {
+    it('should return the dependency in a string representation', () => {
+      const dependency: Dependency = { name: 'foo', version: '1.2.3' };
+      const expectedDependencyString = 'foo@1.2.3';
+
+      const actualDependencyString = getDependencyAsString(dependency);
+
+      assert.strictEqual(actualDependencyString, expectedDependencyString);
+    });
+  });
+});

--- a/src/npm/dependency.ts
+++ b/src/npm/dependency.ts
@@ -1,0 +1,41 @@
+import { sh } from '../cli/shell';
+
+export type Dependency = { name: string; version: string }
+type DependencyObject = { [name: string]: string }
+
+export function convertToDependencyArray(dependencies: DependencyObject): Dependency[] {
+  return Object
+    .entries(dependencies)
+    .map(([name, version]) => {
+      return {
+        name: name,
+        version: version,
+      };
+    });
+}
+
+export function getDependencyAsString(dependency: Dependency): string {
+  return `${dependency.name}@${dependency.version}`;
+}
+
+export function getRegistryInfo(packageName: string) {
+  const registryInfoRaw = sh(`npm view --json ${packageName}`);
+
+  return JSON.parse(registryInfoRaw);
+}
+
+export function getLatestRevision(packageName: string, baseVersion: string, releaseChannelName: string): string {
+  const registryInfo = getRegistryInfo(packageName);
+  const availableVersions = registryInfo.versions as string[];
+  const versionCandidates = availableVersions
+    .filter((versionCandidate) => {
+      if (releaseChannelName === 'stable') {
+        return versionCandidate === baseVersion;
+      }
+
+      return versionCandidate.startsWith(`${baseVersion}-${releaseChannelName}`);
+    })
+    .sort();
+
+  return versionCandidates[versionCandidates.length - 1];
+}


### PR DESCRIPTION
## Changes

1. Add a new command "replace-dist-tags-with-real-versions"
2. Add npm-dependency-related functions and tests
3. Add an optional "pathspec" parameter to "isDirty" (git-related function)

## Issues

PR: #66

## How to test the changes

1. `npm i -g @process-engine/ci_tools@feature~add-command-fail-on-pre-version-dependencies`
2. Navigate to a repository
3. Use dist tags (e.g. "alpha", "beta" or "feature~xyz") for packages
4. Run `ci_tools replace-dist-tags-with-real-versions --dist-tags-to-replace [<dist tag>...] [<package-pattern>...]`
5. Check if dist tags were replaced with real versions

## Examples

<details>
<summary>First example</summary>

Command:
```
ci_tools replace-dist-tags-with-real-versions @atlas-engine/ -d feature
```

Dependencies in package.json before command execution:
```
@atlas-engine/iam: feature~new_awesome_feature
@atlas-engine/timing: 1.0.1-alpha.1
bluebird: 3.7.2
```

Let's assume that "feature~new_awesome_feature" resolves to "1.2.0-feature-9bb68c-k7xhj7gd"

Dependencies in package.json after command execution:
```
@atlas-engine/iam: 1.2.0-alpha.1
@atlas-engine/timing: 1.0.1-alpha.1
bluebird: 3.7.2
```
</details>

<details>
<summary>Second example</summary>

Command:
```
ci_tools replace-dist-tags-with-real-versions @atlas-engine/ -d alpha
```

Dependencies in package.json before command execution:
```
@atlas-engine/iam: alpha
@atlas-engine/timing: 1.0.1-alpha.5
bluebird: 3.7.2
```

Dependencies in package.json after command execution:
```
@atlas-engine/iam: 2.3.0-beta.1
@atlas-engine/timing: 1.0.1-beta.2
bluebird: 3.7.2
```
</details>