### PR TITLE
✨ Add support for Python projects

### DIFF
--- a/src/ci_tools.ts
+++ b/src/ci_tools.ts
@@ -22,6 +22,7 @@ import * as ReplaceDistTagsWithRealVersions from './commands/replace-dist-tags-w
 
 import { getGitBranch } from './git/git';
 import { PRIMARY_BRANCHES } from './versions/increment_version';
+import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE, PACKAGE_MODE_PYTHON } from './contracts/modes';
 
 const COMMAND_HANDLERS = {
   'commit-and-tag-version': CommitAndTagVersion,
@@ -47,7 +48,7 @@ const INTERNAL_COMMAND_HANDLERS = {
   'setup-git-and-npm-connections': SetupGitAndNpmConnections
 };
 
-const DEFAULT_MODE = 'node';
+const DEFAULT_MODE = PACKAGE_MODE_NODE;
 
 async function run(originalArgv: string[]): Promise<void> {
   const [, , ...args] = originalArgv;
@@ -59,8 +60,8 @@ async function run(originalArgv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  if (mode !== 'dotnet' && mode !== DEFAULT_MODE) {
-    console.error('Mode must be set to `dotnet` or `node`. \nDefault is `node`');
+  if (mode !== PACKAGE_MODE_NODE && mode !== PACKAGE_MODE_DOTNET && mode !== PACKAGE_MODE_PYTHON) {
+    console.error('Mode must be set to `dotnet`, `node` or `python`. \nDefault is `node`');
     process.exit(1);
   }
 

--- a/src/commands/commit-and-tag-version.ts
+++ b/src/commands/commit-and-tag-version.ts
@@ -9,7 +9,7 @@ import { setupGit } from './internal/setup-git-and-npm-connections';
 import { sh } from '../cli/shell';
 import { isRedundantRunTriggeredBySystemUserPush, isRetryRunForPartiallySuccessfulBuild } from '../versions/retry_run';
 import { printMultiLineString } from '../cli/printMultiLineString';
-import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE } from '../contracts/modes';
+import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE, PACKAGE_MODE_PYTHON } from '../contracts/modes';
 
 const COMMAND_NAME = 'commit-and-tag-version';
 const BADGE = `[${COMMAND_NAME}]\t`;
@@ -128,6 +128,9 @@ function addPackageFilesToGit(mode: string): void {
     case PACKAGE_MODE_NODE:
       gitAdd('package.json');
       gitAdd('package-lock.json');
+      break;
+    case PACKAGE_MODE_PYTHON:
+      gitAdd('setup.py');
       break;
     default:
       throw new Error(`Unknown value for \`mode\`: ${mode}`);

--- a/src/commands/copy-and-commit-version-for-subpackage.ts
+++ b/src/commands/copy-and-commit-version-for-subpackage.ts
@@ -16,6 +16,10 @@ const DEFAULT_MODE = 'node';
 
 const DOC = `
 Copies the version from the main package to a subpackage and commits the change.
+
+OPTIONS
+
+--mode    sets the package mode [dotnet, node, python] (default: node)
 `;
 // DOC: see above
 
@@ -53,7 +57,7 @@ export function getShortDoc(): string {
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ci_tools ${COMMAND_NAME} <subpackageLocation> [--dry] [--force]`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} <subpackageLocation> [--dry] [--force] [--mode <MODE>]`);
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/commands/get-version.ts
+++ b/src/commands/get-version.ts
@@ -9,8 +9,7 @@ Returns the package version.
 
 OPTIONS
 
---mode    sets the package mode [dotnet, node] (default: node)
-
+--mode    sets the package mode [dotnet, node, python] (default: node)
 `;
 
 export async function run(...args): Promise<boolean> {

--- a/src/commands/prepare-version.ts
+++ b/src/commands/prepare-version.ts
@@ -17,14 +17,15 @@ const BADGE = `[${COMMAND_NAME}]\t`;
 const DEFAULT_MODE = 'node';
 
 const DOC = `
-Adjusts the pre-version in your project file automatically (\`package.json\` for Node or \`*.csproj\` for C# .NET).
+Adjusts the pre-version in your project file automatically (\`package.json\` for Node, \`*.csproj\` for C# .NET
+or \`setup.py\` for Python).
 
 OPTIONS
 
 --allow-dirty-workdir   allows for a "dirty" Git workdir
 --dry                   performs a dry which does not changes any files
 --force                 overrides all plausibility checks and increments the pre-version
---mode                  sets the package mode [dotnet, node] (default: node)
+--mode                  sets the package mode [dotnet, node, python] (default: node)
 
 EXAMPLES
 

--- a/src/commands/publish-releasenotes-on-slack.ts
+++ b/src/commands/publish-releasenotes-on-slack.ts
@@ -16,6 +16,10 @@ const DOC = `
 Publishes the releasenotes for the current version on slack.
 
 To use this command, an incoming webhook for slack is required and must be configured as an environment variable named 'SLACK_WEBHOOK'.
+
+OPTIONS
+
+--mode    sets the package mode [dotnet, node, python] (default: node)
 `;
 // DOC: see above
 
@@ -41,7 +45,7 @@ export function getShortDoc(): string {
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ci_tools ${COMMAND_NAME}`);
+  console.log(`Usage: ci_tools ${COMMAND_NAME} [--mode <MODE>]`);
   console.log('');
   console.log(DOC.trim());
 }

--- a/src/commands/set-version.ts
+++ b/src/commands/set-version.ts
@@ -9,7 +9,7 @@ Sets the package version.
 
 OPTIONS
 
---mode      sets the package mode [dotnet, node] (default: node)
+--mode      sets the package mode [dotnet, node, python] (default: node)
 --version   the version to be set
 `;
 

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -24,6 +24,10 @@ const DOC = `
 Updates or creates a GitHub release using the current version (or given \`--version-tag\`).
 
 Uploads all given \`--assets\`, resolving globs and updating existing assets on GitHub.
+
+OPTIONS
+
+--mode    sets the package mode [dotnet, node, python] (default: node)
 `;
 // DOC: see above
 
@@ -88,7 +92,8 @@ export function getShortDoc(): string {
 
 export function printHelp(): void {
   console.log(
-    `Usage: ci_tools ${COMMAND_NAME} [--use-title-and-text-from-git-tag | --title [--text]] [--assets <asset-name-or-glob> ...] [--version-tag] [--dry]`
+    `Usage: ci_tools ${COMMAND_NAME} [--use-title-and-text-from-git-tag | --title [--text]] [--assets <asset-name-or-glob> ...]
+                                      [--version-tag] [--dry] [--mode <MODE>]`
   );
   console.log('');
   console.log(DOC.trim());

--- a/src/contracts/modes.ts
+++ b/src/contracts/modes.ts
@@ -1,2 +1,3 @@
 export const PACKAGE_MODE_DOTNET = 'dotnet';
 export const PACKAGE_MODE_NODE = 'node';
+export const PACKAGE_MODE_PYTHON = 'python';

--- a/src/versions/package_version.ts
+++ b/src/versions/package_version.ts
@@ -1,6 +1,7 @@
 import { getPackageVersionDotnet, setPackageVersionDotnet } from './package_version/dotnet';
 import { getPackageVersionNode, setPackageVersionNode } from './package_version/node';
-import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE } from '../contracts/modes';
+import { PACKAGE_MODE_DOTNET, PACKAGE_MODE_NODE, PACKAGE_MODE_PYTHON } from '../contracts/modes';
+import { getPackageVersionPython, setPackageVersionPython } from './package_version/python';
 
 const versionRegex = /^(\d+)\.(\d+).(\d+)/;
 
@@ -10,6 +11,8 @@ export async function getPackageVersion(mode: string): Promise<string> {
       return getPackageVersionDotnet();
     case PACKAGE_MODE_NODE:
       return getPackageVersionNode();
+    case PACKAGE_MODE_PYTHON:
+      return getPackageVersionPython();
     default:
       throw new Error(`Unknown value for \`mode\`: ${mode}`);
   }
@@ -32,6 +35,9 @@ export async function setPackageVersion(mode: string, version: string): Promise<
       return;
     case PACKAGE_MODE_NODE:
       setPackageVersionNode(version);
+      return;
+    case PACKAGE_MODE_PYTHON:
+      setPackageVersionPython(version);
       return;
     default:
       throw new Error(`Unknown value for \`mode\`: ${mode}`);

--- a/src/versions/package_version/python.ts
+++ b/src/versions/package_version/python.ts
@@ -1,0 +1,22 @@
+import { StdioOptions, execSync } from 'child_process';
+import * as fs from 'fs';
+
+export function getPackageVersionPython(): string {
+  // Pass stderr to the parent process
+  const stdioOptions: StdioOptions = ['pipe', 'pipe', 'inherit'];
+
+  const versionRaw = execSync('python3 setup.py --version', { encoding: 'utf-8', stdio: stdioOptions });
+  const version = versionRaw.trim();
+
+  return version;
+}
+
+export function setPackageVersionPython(version: string): void {
+  // It seems that the setup.py cli does not provide a command to set the package version, so this function will resort
+  // to simply string-replacing the version in the setup.py file.
+  // Loading the whole file into memory should be fine as setup.py files tend to be quite small in file size.
+  const currentVersion = getPackageVersionPython();
+  const setupContent = fs.readFileSync('setup.py', { encoding: 'utf-8' });
+
+  fs.writeFileSync('setup.py', setupContent.replace(currentVersion, version));
+}


### PR DESCRIPTION
## Changes

1. Add support for Python projects
2. Add missing documentation for "--mode" option. Some commands lack documentation for their other options which I won't fix in this PR, but I created an issue regarding that matter (#69).

PR: #68 

## How to test the changes

1. `npm i -g @process-engine/ci_tools@feature~python_versioning_support`
1. Navigate to a Python project (e.g. https://github.com/atlas-engine/process_engine-python)
1. `ci_tools prepare-version --mode python --allow-dirty-workdir`
1. A new version should have been written to setup.py