### PR TITLE
Remove productName from releaseHeadline

### DIFF
--- a/src/commands/internal/create-release-announcement.ts
+++ b/src/commands/internal/create-release-announcement.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import fetch from 'node-fetch';
 import * as moment from 'moment';
 
-import { getProductName } from '../../product_name/product_name';
 import { PullRequest, getMergedPullRequests } from '../../github/pull_requests';
 import { getCurrentApiBaseUrlWithAuth, getCurrentRepoNameWithOwner, getGitCommitListSince } from '../../git/git';
 import { getPrevVersionTag, getVersionTag } from '../../versions/git_helpers';
@@ -29,9 +28,8 @@ export async function getReleaseAnnouncement(mode: string): Promise<string> {
   const startRef: string = await getPrevVersionTag(mode);
   const nextVersion = await getPackageVersion(mode);
   const nextVersionTag = getVersionTag(nextVersion);
-  const productName = await getProductName(mode);
 
-  const releaseHeadline = `*${productName} ${nextVersionTag} was released!*`;
+  const releaseHeadline = `*${nextVersionTag} was released!*`;
 
   if (startRef == null) {
     return releaseHeadline;


### PR DESCRIPTION
Im techn. Meet besprochen - entfernt den `productName` aus den Release-Announcements, da dieser bereits als Produkt-Name in dem Announcer-Name wiedergespiegelt wird und teilweise zu technisch für ein derartiges Announcement ist. Wir wollen damit die Announcements übersichtlicher gestalten. Im Zuge dessen werden einige Announcer-Namen angepasst, damit diese den Produkt-Namen besser wiederspiegeln.

Vorher:

### AtlasEngine Release Announcer
**@atlas-engine/fullstack_server v10.2.0 was released!**
The new version includes the following changes:
- :bug: Allow regular users to run processes with ExternalTasks
- :bug: Avoid database creation if database exists
- :bug: Fix null/undefined external task payload

For a more detailed changelog have a look at: http://github.com/atlas-engine/AtlasEngine/releases/tag/v10.2.0


Jetzt:

### Atlas Engine
**v10.2.0 was released!**
The new version includes the following changes:
- :bug: Allow regular users to run processes with ExternalTasks
- :bug: Avoid database creation if database exists
- :bug: Fix null/undefined external task payload

For a more detailed changelog have a look at: http://github.com/atlas-engine/AtlasEngine/releases/tag/v10.2.0
