### PR TITLE
Add Breaking text to changelog and release announcement

### DIFF
--- a/src/commands/internal/create-changelog.ts
+++ b/src/commands/internal/create-changelog.ts
@@ -106,6 +106,10 @@ export async function getChangelogText(mode: string, startRef: string): Promise<
       const mergedAt = moment(pr.mergedAt).format('YYYY-MM-DD');
       const title = ensureSpaceAfterLeadingEmoji(pr.title);
 
+      if (pr.isBreakingChange) {
+        return `- #${pr.number} BREAKING: ${title} (merged ${mergedAt})`;
+      }
+
       return `- #${pr.number} ${title} (merged ${mergedAt})`;
     })
     .join('\n');

--- a/src/commands/internal/create-release-announcement.ts
+++ b/src/commands/internal/create-release-announcement.ts
@@ -83,6 +83,10 @@ ${releaseTagLinkFooter}
     .map((pr: PullRequest): string => {
       const title = ensureSpaceAfterLeadingEmoji(pr.title);
 
+      if (pr.isBreakingChange) {
+        return `- BREAKING: ${title}`;
+      }
+
       return `- ${title}`;
     })
     .join('\n');

--- a/src/github/pull_requests.ts
+++ b/src/github/pull_requests.ts
@@ -11,6 +11,7 @@ export type PullRequest = {
   headSha: string;
   mergeCommitSha: string;
   mergedAt: string;
+  isBreakingChange: boolean;
 };
 
 const PULL_REQUEST_INDEX_API_URI = getCurrentApiBaseUrlWithAuth('/pulls?state=closed');
@@ -27,13 +28,18 @@ async function fetchPullRequests(since: string): Promise<PullRequest[]> {
 
   return pullRequestsSince.map(
     (pr: PullRequestFromApi): PullRequest => {
+      const isBreakingChange = pr.labels.find(
+        (label: any): boolean => label.name.toLowerCase().includes('breaking')
+      );
+
       return {
         number: pr.number,
         title: pr.title,
         closedIssueNumbers: findIssueNumbers(pr.body),
         mergeCommitSha: pr.merge_commit_sha,
         headSha: pr.head.sha,
-        mergedAt: pr.merged_at
+        mergedAt: pr.merged_at,
+        isBreakingChange: isBreakingChange,
       };
     }
   );


### PR DESCRIPTION
## Changes

1. Fügt den Prefix `Breaking:` an Changelog Einträge für geschlossene PRs mit `Breaking Change`-Label hinzu.
1. Fügt den Prefix `Breaking:` an Release Announcement Einträge für geschlossene PRs mit `Breaking Change`-Label hinzu.

