### PR TITLE
Add previous pre version steps in beta releases

### DIFF
--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -12,6 +12,10 @@ export function getGitTagList(): string {
   return sh('git tag --sort=-creatordate').trim();
 }
 
+export function getGitTagDate(tag: string): string {
+  return sh(`git log -1 --format=%ai ${tag}`).trim();
+}
+
 export function getGitCommitListSince(ref: string, since: string): string {
   return sh(`git log --format="%H" --since ${since} ${ref}`).trim();
 }


### PR DESCRIPTION
Fügt den Release Notes von Betas zusätzliche Zwischenüberschriften hinzu, um leichter zu erkennen, was in welcher Beta hinzugekommen ist:

![image](https://user-images.githubusercontent.com/311914/97196777-27d53f80-17ad-11eb-9c30-5c76e4271ea7.png)

Closes #74 
