### PR TITLE
Fix release header for current release in create-changelog

### DIFF
--- a/src/commands/internal/create-changelog.ts
+++ b/src/commands/internal/create-changelog.ts
@@ -114,7 +114,7 @@ export async function getChangelogText(mode: string, startRef: string): Promise<
 
   const previousPreVersions = getPreviousPreVersionsInReleaseChannel(nextVersion);
   const shouldShowPreviousPreVersions = previousPreVersions.length > 0;
-  let currentPreviousPreVersion = shouldShowPreviousPreVersions ? { tag: nextVersion, date: new Date() } : null;
+  let currentPreviousPreVersion = shouldShowPreviousPreVersions ? { tag: nextVersionTag, date: new Date() } : null;
   let currentPreviousPreVersionIndex = -1;
 
   const mergedPullRequestsText = mergedPullRequests


### PR DESCRIPTION
Fixt einen Typo bei der Erstellung der Changelogs, wodurch

```
11.0.0-beta.7 (this release)
```

zu

```
v11.0.0-beta.7 (this release)
```

korrigiert wird (man beachte das vorangestellte `v`).