### PR TITLE
Fix release announcement pr url

### DIFF
--- a/src/commands/internal/create-release-announcement.ts
+++ b/src/commands/internal/create-release-announcement.ts
@@ -42,7 +42,7 @@ export async function getReleaseAnnouncement(mode: string): Promise<string> {
   const nextVersionTag = getVersionTag(nextVersion);
   const repoUrl = `http://github.com/${getCurrentRepoNameWithOwner()}`;
   const releaseTagUrl = `${repoUrl}/releases/tag/${nextVersionTag}`;
-  const getPrUrl = (number: number): string => `${repoUrl}/pulls/${number}`;
+  const getPrUrl = (number: number): string => `${repoUrl}/pull/${number}`;
 
   const releaseHeadline = `*${nextVersionTag}* was released!`;
   const releaseTagLinkFooter = `Please see the <${releaseTagUrl}|full CHANGELOG> for details.`;


### PR DESCRIPTION
Korrigiert einen Fehler in der PR-URL, die für Release-Announcements generiert wird. Es muss `pull` und nicht `pulls` heißen um direkt auf einen PR zu verlinken.

Siehe bspw:
[vorher](https://github.com/atlas-engine/AtlasEngine/pulls/267) `https://github.com/atlas-engine/AtlasEngine/pulls/267`
[nachher](https://github.com/atlas-engine/AtlasEngine/pull/267) `https://github.com/atlas-engine/AtlasEngine/pull/267`