### PR TITLE
Fix updating GitHub release if no release exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/ci_tools",
-  "version": "3.2.0-alpha.12",
+  "version": "3.3.0-alpha.1",
   "description": "CI tools for process-engine.io",
   "main": "dist/ci_tools.js",
   "scripts": {

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -218,7 +218,6 @@ async function createNewRelease(
   });
 
   const success = response.status === 200;
-  console.log('CI Tools createReleaseResponsee: ', JSON.stringify(response, null, 2));
   if (success) {
     const releaseId = response.data.id;
 

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -218,10 +218,11 @@ async function createNewRelease(
   });
 
   const success = response.status === 200;
+  console.log('CI Tools createReleaseResponsee: ', JSON.stringify(response, null, 2));
   if (success) {
     const releaseId = response.data.id;
 
-    await updateExistingRelease(octokit, repo, releaseId, null, null, assets);
+    return await updateExistingRelease(octokit, repo, releaseId, null, null, assets);
   }
 
   return success;

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -217,7 +217,7 @@ async function createNewRelease(
     prerelease: isPrerelease
   });
 
-  const success = response.status === 200;
+  const success = response.status === 201;
   if (success) {
     const releaseId = response.data.id;
 

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -221,7 +221,7 @@ async function createNewRelease(
   if (success) {
     const releaseId = response.data.id;
 
-    return await updateExistingRelease(octokit, repo, releaseId, null, null, assets);
+    return await updateExistingRelease(octokit, repo, releaseId, title, text, assets);
   }
 
   return success;

--- a/src/commands/update-github-release.ts
+++ b/src/commands/update-github-release.ts
@@ -221,7 +221,7 @@ async function createNewRelease(
   if (success) {
     const releaseId = response.data.id;
 
-    return await updateExistingRelease(octokit, repo, releaseId, title, text, assets);
+    return updateExistingRelease(octokit, repo, releaseId, title, text, assets);
   }
 
   return success;


### PR DESCRIPTION
## Changes

1. Fix wrong status code
2. Return the correct `success`
3. Provide title and text 

## Issues

PR: #94 

## How to test the changes

try to use 

`ci_tools update-github-release 
                --assets <your-file>`

if the release does not exist yet.
Before this PR, the release would be created while executing this command, but no assets were uploaded.