### PR TITLE
Fix tagging npm package if workflow was started by tag event

### DIFF
--- a/src/commands/copy-and-commit-version-for-subpackage.ts
+++ b/src/commands/copy-and-commit-version-for-subpackage.ts
@@ -47,8 +47,8 @@ export async function run(...args): Promise<boolean> {
   process.chdir(cwd);
 
   const branchName = getGitBranch();
-
-  gitAdd(`${subpackageLocationWithSlash}package.json`);
+  const filename = getSubpackageFilename(mode, subpackageLocationWithSlash);
+  gitAdd(`${subpackageLocationWithSlash}${filename}`);
 
   sh('git status');
 
@@ -143,6 +143,24 @@ async function getSubpackageDotnet(subpackageLocation: string): Promise<any> {
   }
 
   return json;
+}
+
+function getSubpackageFilename(mode: string, subpackageLocation: string): string {
+  switch (mode) {
+    case PACKAGE_MODE_DOTNET:
+      const cwd = process.cwd();
+      process.chdir(subpackageLocation);
+      const filename = getCsprojPath();
+      process.chdir(cwd);
+
+      return filename;
+    case PACKAGE_MODE_NODE:
+      return 'package.json';
+    case PACKAGE_MODE_PYTHON:
+      return 'setup.py';
+    default:
+      break;
+  }
 }
 
 function getSubpackageLocationFromArgs(args): string | undefined {

--- a/src/git/git.test.ts
+++ b/src/git/git.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import { getBranchFromRefTag, mapReleaseChannelNameToBranch } from './git';
+
+describe('git.ts', () => {
+  describe('getBranchFromRefTag()', () => {
+    it('should return the right branch name for tag references', () => {
+      assert.strictEqual(getBranchFromRefTag('refs/tags/v1.0.0-alpha.18'), 'develop');
+      assert.strictEqual(getBranchFromRefTag('refs/tags/v1.0.0-beta.18'), 'beta');
+      assert.strictEqual(getBranchFromRefTag('refs/tags/v1.0.0'), 'master');
+    });
+
+    it('should return null if tag reference is not valid semver', () => {
+      assert.strictEqual(getBranchFromRefTag('refs/tags/v1dd.0.0-alpha.18'), null);
+      assert.strictEqual(getBranchFromRefTag('v1.0ddds.0-beta.18'), null);
+      assert.strictEqual(getBranchFromRefTag('refs/tags/myIndividualTagWithoutAVersion'), null);
+    });
+  });
+
+  describe('mapReleaseChannelNameToBranch()', () => {
+    it('should map the release channels to branch names', () => {
+      assert.strictEqual(mapReleaseChannelNameToBranch('alpha'), 'develop');
+      assert.strictEqual(mapReleaseChannelNameToBranch('beta'), 'beta');
+      assert.strictEqual(mapReleaseChannelNameToBranch('stable'), 'master');
+    });
+
+    it('should return undefined if the release channel is not known', () => {
+      assert.strictEqual(mapReleaseChannelNameToBranch('channel'), undefined);
+    });
+  });
+});

--- a/src/versions/package_version/dotnet.ts
+++ b/src/versions/package_version/dotnet.ts
@@ -50,6 +50,10 @@ function getCsprojAsObject(filePath: string): Promise<any> {
 function getCsprojPath(): string {
   const paths = glob.sync(CSPROJ_FILE_GLOB);
 
+  if (paths.length === 0) {
+    throw new Error('No csproj file found.');
+  }
+
   if (paths.length > 1) {
     throw new Error(`More than one .csproj file found: ${paths.join('\n')}`);
   }

--- a/src/versions/package_version/dotnet.ts
+++ b/src/versions/package_version/dotnet.ts
@@ -41,13 +41,13 @@ export async function setPackageVersionDotnet(newVersion: string): Promise<void>
   fs.writeFileSync(pathToCsproj, csProjWithNewVersion);
 }
 
-function getCsprojAsObject(filePath: string): Promise<any> {
+export function getCsprojAsObject(filePath: string): Promise<any> {
   const contents = fs.readFileSync(filePath, { encoding: 'utf8' });
 
   return parseStringPromise(contents.toString());
 }
 
-function getCsprojPath(): string {
+export function getCsprojPath(): string {
   const paths = glob.sync(CSPROJ_FILE_GLOB);
 
   if (paths.length === 0) {


### PR DESCRIPTION
Die CI Tools publishen alpha Versionen eines npm Pakets nicht unter dem Alpha-Tag, wenn der Build über ein Tag/Release Event getriggert wurde, sondern unter z.B. `refs~tags~v1.0.0-alpha.19` (Atlas Studio). 
![Bildschirmfoto 2021-01-27 um 15 32 53](https://user-images.githubusercontent.com/17065920/106005877-f3776500-60b4-11eb-9161-40193999ddf8.png).

Das liegt daran dass im GitHub Kontext des Runners `github.ref` in diesem Fall nicht `refs/heads/<branchname>` sondern `refs/tags/<tagname>` ist. 

## Changes

1. Passt die getGitBranch Funktion an sodass im Falle von `refs/tags/<tagname>` der Branchname zurückgegeben wird, vorrausgesetzt der `<tagname>` ist Semver konform. 
2. Falls der Branchname trotzdem nicht ermittelt werden kann, wird die Package Version ausgelesen und der Release Kanal zum Branchnamen gemappt.

## Issues

PR: #96 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
